### PR TITLE
Fix unsafe no-std (#15)

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -30,6 +30,16 @@ jobs:
       - name: Compile and run tests
         run: cargo test --no-fail-fast --lib --no-default-features
 
+  test-unsafe:
+    name: "Test (unsafe)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rust dependency cache
+        uses: Swatinem/rust-cache@v2
+      - name: Compile and run tests
+        run: cargo test --no-fail-fast --lib --no-default-features --features unsafe
+
   test-msrv:
     name: "Test (MSRV)"
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapidhash"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 rust-version = "1.77.0"
 authors = ["Liam Gray <gmail@liamg.me>"]

--- a/src/rapid_const.rs
+++ b/src/rapid_const.rs
@@ -155,7 +155,7 @@ const fn read_u32(slice: &[u8], offset: usize) -> u32 {
 pub(crate) const fn read_u64(slice: &[u8], offset: usize) -> u64 {
     debug_assert!(offset as isize >= 0);
     debug_assert!(slice.len() >= 8 + offset);
-    let val = unsafe { std::ptr::read_unaligned(slice.as_ptr().offset(offset as isize) as *const u64) };
+    let val = unsafe { core::ptr::read_unaligned(slice.as_ptr().offset(offset as isize) as *const u64) };
     val.to_le()  // swap bytes on big-endian systems to get the same u64 value
 }
 
@@ -169,7 +169,7 @@ pub(crate) const fn read_u64(slice: &[u8], offset: usize) -> u64 {
 const fn read_u32(slice: &[u8], offset: usize) -> u32 {
     debug_assert!(offset as isize >= 0);
     debug_assert!(slice.len() >= 4 + offset);
-    let val = unsafe { std::ptr::read_unaligned(slice.as_ptr().offset(offset as isize) as *const u32) };
+    let val = unsafe { core::ptr::read_unaligned(slice.as_ptr().offset(offset as isize) as *const u32) };
     val.to_le()  // swap bytes on big-endian systems to get the same u64 value
 }
 


### PR DESCRIPTION
Switch from using `std::ptr` to `core::ptr`, bug identified in #15.