### PR TITLE
Fix benchmarks for rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,10 @@ tempfile = "3.14.0"
 # benchmarking helpers
 criterion = { version = "0.5.1", default-features = false, features = ["rayon", "cargo_bench_support"] }
 rand = "0.9.0"
+rand8 = { package = "rand", version = "0.8.0" }
 const-random = "0.1.18"
 lazy_static = "1.5.0"
-reqwest = { version = "0.12.7", features = ["blocking"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["http2", "blocking", "rustls-tls"] }
 itertools = "0.14.0"
 
 # for the charts example to generate README plots

--- a/benches/compiled.rs
+++ b/benches/compiled.rs
@@ -1,7 +1,6 @@
 use const_random::const_random;
 use criterion::{Bencher, Criterion};
-use rand::Rng;
-use rand::seq::SliceRandom;
+use rand::prelude::*;
 use rapidhash::{rapidhash, RapidHashMap};
 
 /// Benchmark approaches for matching bytes against compile-time known values.
@@ -114,13 +113,13 @@ const HASHES: [u64; INPUT_COUNT] = {
 
 const MISMATCH_PCT: u8 = 20;
 fn random_input() -> [u8; INPUT_LEN] {
-    let mismatch_branch = rand::thread_rng().gen_range(0..100);
+    let mismatch_branch = rand::rng().random_range(0..100);
     if mismatch_branch < MISMATCH_PCT {
         let mut buffer = [0u8; INPUT_LEN];
-        rand::thread_rng().fill(&mut buffer);
+        rand::rng().fill(&mut buffer);
         buffer
     } else {
-        *INPUTS.choose(&mut rand::thread_rng()).unwrap()
+        *INPUTS.choose(&mut rand::rng()).unwrap()
     }
 }
 

--- a/benches/hashmap.rs
+++ b/benches/hashmap.rs
@@ -1,6 +1,7 @@
 use std::hash::BuildHasherDefault;
 use criterion::{Bencher, Criterion, Throughput};
-use rand::distributions::{Alphanumeric, DistString, Distribution, WeightedIndex};
+use rand::distr::weighted::WeightedIndex;
+use rand::distr::{Alphanumeric, Distribution, SampleString};
 use rand::Rng;
 use wyhash::WyHash;
 
@@ -88,8 +89,8 @@ fn sample_string(count: usize, min: usize, max: usize) -> Vec<String> {
 
     (0..count)
         .map(|_| {
-            let len = rand::thread_rng().gen_range(min..=max);
-            let s: String = rand::thread_rng()
+            let len = rand::rng().random_range(min..=max);
+            let s: String = rand::rng()
                 .sample_iter(&Alphanumeric)
                 .take(len)
                 .map(char::from)
@@ -100,7 +101,7 @@ fn sample_string(count: usize, min: usize, max: usize) -> Vec<String> {
 }
 
 fn sample_emails(count: usize) -> Vec<String> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // weights roughly estimated from https://atdata.com/blog/long-email-addresses/
     let weights = [
@@ -125,7 +126,7 @@ fn sample_emails(count: usize) -> Vec<String> {
 
 fn sample_u64(count: usize) -> Vec<u64> {
     (0..count)
-        .map(|_| rand::thread_rng().gen_range(0..500000))
+        .map(|_| rand::rng().random_range(0..500000))
         .collect()
 }
 
@@ -141,16 +142,16 @@ struct Object {
 }
 
 fn sample_object(count: usize) -> Vec<Object> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut objects = Vec::with_capacity(count);
     for _ in 0..count {
-        let url_len = rng.gen_range(30..=70);
-        let event_data_len = rng.gen_range(250..=450);
+        let url_len = rng.random_range(30..=70);
+        let event_data_len = rng.random_range(250..=450);
 
         objects.push(Object {
-            time_sec: rng.gen(),
-            time_ns: rng.gen(),
-            user_id: rng.gen(),
+            time_sec: rng.random(),
+            time_ns: rng.random(),
+            user_id: rng.random(),
             url: Alphanumeric.sample_string(&mut rng, url_len),
             event_source: Alphanumeric.sample_string(&mut rng, 20),
             event_data: Alphanumeric.sample_string(&mut rng, event_data_len),

--- a/benches/rng.rs
+++ b/benches/rng.rs
@@ -1,4 +1,6 @@
 use criterion::{Bencher, Criterion};
+use rand8::RngCore as RngCore8;
+use rand8::SeedableRng as SeedableRng8;
 use rand_core::{RngCore, SeedableRng};
 
 macro_rules! bench_rng {

--- a/benches/vector.rs
+++ b/benches/vector.rs
@@ -1,7 +1,6 @@
 use std::hash::Hasher;
 use criterion::Bencher;
 use rand::Rng;
-use rand::rngs::OsRng;
 use rapidhash::RAPID_SEED;
 
 /// Use .iter_batched_ref to avoid paying the Vec destruction cost, as it's 10x
@@ -10,7 +9,7 @@ pub fn bench_rapidhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = rapidhash::RapidHasher::default();
@@ -24,7 +23,7 @@ pub fn bench_rapidhash_raw(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             rapidhash::rapidhash_inline(&bytes, RAPID_SEED)
@@ -36,7 +35,7 @@ pub fn bench_default(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = std::collections::hash_map::DefaultHasher::default();
@@ -50,7 +49,7 @@ pub fn bench_fxhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = fxhash::FxHasher::default();
@@ -64,7 +63,7 @@ pub fn bench_t1ha(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = t1ha::T1haHasher::default();
@@ -78,7 +77,7 @@ pub fn bench_wyhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = wyhash::WyHash::default();
@@ -92,7 +91,7 @@ pub fn bench_wyhash_raw(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             wyhash::wyhash(&bytes, 0)
@@ -104,7 +103,7 @@ pub fn bench_xxhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = twox_hash::XxHash::default();
@@ -118,7 +117,7 @@ pub fn bench_metrohash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = metrohash::MetroHash::default();
@@ -132,7 +131,7 @@ pub fn bench_seahash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = seahash::SeaHasher::default();
@@ -146,7 +145,7 @@ pub fn bench_ahash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = ahash::AHasher::default();
@@ -160,7 +159,7 @@ pub fn bench_gxhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = gxhash::GxHasher::default();
@@ -174,7 +173,7 @@ pub fn bench_farmhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = farmhash::FarmHasher::default();
@@ -188,7 +187,7 @@ pub fn bench_highwayhash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = highway::HighwayHasher::default();
@@ -202,7 +201,7 @@ pub fn bench_rustchash(size: usize) -> Box<dyn FnMut(&mut Bencher)> {
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; size];
-            OsRng.fill(slice.as_mut_slice());
+            rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             let mut hasher = rustc_hash::FxHasher::default();

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -12,13 +12,13 @@ cargo test --no-default-features --lib
 cargo +1.77.0 test --all-features
 
 # Run all benchmarks (assumes cargo-criterion is installed)
-cargo criterion --bench bench --all-features
+RUSTFLAGS="-C target-cpu=native" cargo criterion --bench bench --all-features
 
 # Run all benchmarks, but unsafe=disabled
-cargo criterion --bench bench --features rng
+RUSTFLAGS="-C target-cpu=native" cargo criterion --bench bench --features rng
 
 # Run quality tests across various hash functions
-cargo bench --bench quality --all-features
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench quality --all-features
 ```
 
 ## Fuzzing


### PR DESCRIPTION
Also includes flags for target-cpu in CHEATSHEET, as suggested in #7.