### PR TITLE
Add user-controlled secret params for persistent hashing

### DIFF
--- a/rapidhash/src/util/macros.rs
+++ b/rapidhash/src/util/macros.rs
@@ -67,18 +67,41 @@ macro_rules! compare_rapidhash_file {
         #[test]
         fn $test() {
             use rand::RngCore;
-    
+
             const LENGTH: usize = 1024;
             for len in 1..=LENGTH {
                 let mut data = vec![0u8; len];
                 rand::rng().fill_bytes(&mut data);
-    
+
                 let mut file = tempfile::tempfile().unwrap();
                 file.write_all(&data).unwrap();
                 file.seek(SeekFrom::Start(0)).unwrap();
-    
+
                 assert_eq!(
                     $hash(&data, crate::v1::RAPID_SEED),
+                    $file(&mut file, crate::v1::RAPID_SEED).unwrap(),
+                    "Mismatch for input len: {}", &data.len()
+                );
+            }
+        }
+    };
+
+    ($test:ident, $hash:path, $file:path, $secrets:expr) => {
+        #[test]
+        fn $test() {
+            use rand::RngCore;
+
+            const LENGTH: usize = 1024;
+            for len in 1..=LENGTH {
+                let mut data = vec![0u8; len];
+                rand::rng().fill_bytes(&mut data);
+
+                let mut file = tempfile::tempfile().unwrap();
+                file.write_all(&data).unwrap();
+                file.seek(SeekFrom::Start(0)).unwrap();
+
+                assert_eq!(
+                    $hash(&data, crate::v1::RAPID_SEED, $secrets),
                     $file(&mut file, crate::v1::RAPID_SEED).unwrap(),
                     "Mismatch for input len: {}", &data.len()
                 );

--- a/rapidhash/src/v3/rapid_const.rs
+++ b/rapidhash/src/v3/rapid_const.rs
@@ -5,7 +5,7 @@ use crate::util::read::{read_u32, read_u64};
 pub const RAPID_SEED: u64 = 0;
 
 /// Rapidhash secret parameters.
-pub(super) const RAPID_SECRET: [u64; 8] = [
+pub(super) const RAPID_SECRET: [u64; 7] = [
     0x2d358dccaa6c78a5,
     0x8bb84b93962eacc9,
     0x4b33a62ed433d4a3,
@@ -13,7 +13,6 @@ pub(super) const RAPID_SECRET: [u64; 8] = [
     0xa0761d6478bd642f,
     0xe7037ed1a0b428db,
     0x90ed1765281c388c,
-    0xaaaaaaaaaaaaaaaa,
 ];
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation, with the default seed.
@@ -21,15 +20,21 @@ pub(super) const RAPID_SECRET: [u64; 8] = [
 /// Fixed length inputs will greatly benefit from inlining with [rapidhash_inline] instead.
 #[inline]
 pub const fn rapidhash_v3(data: &[u8]) -> u64 {
-    rapidhash_v3_inline::<false, false>(data, RAPID_SEED)
+    rapidhash_v3_inline::<false, false>(data, RAPID_SEED, &RAPID_SECRET)
 }
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation, with a custom seed.
 ///
 /// Fixed length inputs will greatly benefit from inlining with [rapidhash_inline] instead.
+///
+/// Future work: replace the default `RAPID_SECRET` with a secrets parameter for randomised and
+/// user-controlled secret values. There is a trivial collision attack at certain input sizes (such
+/// as 32 bytes) that can be exploited when an attacker knows the secret values. In the meantime,
+/// [rapidhash_v3_inline] can be used instead. For an example of trivial collisions, see
+/// https://github.com/hoxxep/rapidhash/blob/v2.0.2/rapidhash-c/src/lib.rs#L12
 #[inline]
 pub const fn rapidhash_v3_seeded(data: &[u8], seed: u64) -> u64 {
-    rapidhash_v3_inline::<false, false>(data, seed)
+    rapidhash_v3_inline::<false, false>(data, seed, &RAPID_SECRET)
 }
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation.
@@ -42,15 +47,11 @@ pub const fn rapidhash_v3_seeded(data: &[u8], seed: u64) -> u64 {
 ///     may be slower on some platforms. Disabled by default.
 /// - `PROTECTED`: Slightly stronger hash quality and DoS resistance by performing two extra XOR
 ///     instructions on every mix step. Disabled by default.
-///
-/// Future work: replace the default `RAPID_SECRET` with a parameter for randomised or
-/// user-controlled secret values. There is a trivial collision attack at certain input sizes (such
-/// as 32 bytes) that can be exploited when an attacker knows the secret values.
 #[inline(always)]
-pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
+pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(data: &[u8], mut seed: u64, secrets: &[u64; 7]) -> u64 {
     seed = rapidhash_seed(seed);
-    let (a, b, _, remainder) = rapidhash_core::<COMPACT, PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+    let (a, b, _, remainder) = rapidhash_core::<COMPACT, PROTECTED>(0, 0, seed, secrets, data);
+    rapidhash_finish::<PROTECTED>(a, b, secrets, remainder)
 }
 
 /// Rapidhash V3 Micro, a very compact version of the rapidhash algorithm.
@@ -65,10 +66,10 @@ pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(dat
 /// - `PROTECTED`: Slightly stronger hash quality and DoS resistance by performing two extra XOR
 ///     instructions on every mix step. Disabled by default.
 #[inline(always)]
-pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
+pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64, secrets: &[u64; 7]) -> u64 {
     seed = rapidhash_seed(seed);
-    let (a, b, _, remainder) = rapidhash_micro_core::<PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+    let (a, b, _, remainder) = rapidhash_micro_core::<PROTECTED>(0, 0, seed, secrets, data);
+    rapidhash_finish::<PROTECTED>(a, b, secrets, remainder)
 }
 
 /// Rapidhash V3 Nano, a very compact version of the rapidhash algorithm.
@@ -84,10 +85,10 @@ pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], mut s
 /// - `PROTECTED`: Slightly stronger hash quality and DoS resistance by performing two extra XOR
 ///     instructions on every mix step. Disabled by default.
 #[inline(always)]
-pub const fn rapidhash_v3_nano_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
+pub const fn rapidhash_v3_nano_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64, secrets: &[u64; 7]) -> u64 {
     seed = rapidhash_seed(seed);
-    let (a, b, _, remainder) = rapidhash_nano_core::<PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+    let (a, b, _, remainder) = rapidhash_nano_core::<PROTECTED>(0, 0, seed, secrets, data);
+    rapidhash_finish::<PROTECTED>(a, b, secrets, remainder)
 }
 
 #[inline(always)]
@@ -96,7 +97,7 @@ pub(super) const fn rapidhash_seed(seed: u64) -> u64 {
 }
 
 #[inline(always)]
-pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, secrets: &[u64; 7], data: &[u8]) -> (u64, u64, u64, u64) {
     // TODO: benchmark without the a,b XOR -- eg. a oneshot
     let remainder;
     if data.len() <= 16 {
@@ -117,10 +118,10 @@ pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(m
         }
         remainder = data.len() as u64;
     } else {
-        (a, b, seed, remainder) = rapidhash_core_cold::<COMPACT, PROTECTED>(a, b, seed, data);
+        (a, b, seed, remainder) = rapidhash_core_cold::<COMPACT, PROTECTED>(a, b, seed, secrets, data);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
@@ -128,7 +129,7 @@ pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(m
 }
 
 #[inline]
-const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, secrets: &[u64; 7], data: &[u8]) -> (u64, u64, u64, u64) {
     let mut slice = data;
 
     // most CPUs appear to benefit from this unrolled loop
@@ -141,46 +142,46 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
 
     if !COMPACT {
         while slice.len() > 224 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
 
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ RAPID_SECRET[0], read_u64(slice, 120) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ RAPID_SECRET[1], read_u64(slice, 136) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ RAPID_SECRET[2], read_u64(slice, 152) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ RAPID_SECRET[3], read_u64(slice, 168) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ RAPID_SECRET[4], read_u64(slice, 184) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ RAPID_SECRET[5], read_u64(slice, 200) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ RAPID_SECRET[6], read_u64(slice, 216) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ secrets[0], read_u64(slice, 120) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ secrets[1], read_u64(slice, 136) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ secrets[2], read_u64(slice, 152) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ secrets[3], read_u64(slice, 168) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ secrets[4], read_u64(slice, 184) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ secrets[5], read_u64(slice, 200) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ secrets[6], read_u64(slice, 216) ^ see6);
 
             let (_, split) = slice.split_at(224);
             slice = split;
         }
 
         if slice.len() > 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
             let (_, split) = slice.split_at(112);
             slice = split;
         }
     } else {
         while slice.len() > 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
             let (_, split) = slice.split_at(112);
             slice = split;
         }
@@ -194,17 +195,17 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
     seed ^= see2;
 
     if slice.len() > 16 {
-        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
         if slice.len() > 32 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             if slice.len() > 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[1], read_u64(slice, 40) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[1], read_u64(slice, 40) ^ seed);
                 if slice.len() > 64 {
-                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[1], read_u64(slice, 56) ^ seed);
+                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[1], read_u64(slice, 56) ^ seed);
                     if slice.len() > 80 {
-                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[2], read_u64(slice, 72) ^ seed);
+                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[2], read_u64(slice, 72) ^ seed);
                         if slice.len() > 96 {
-                            seed = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[1], read_u64(slice, 88) ^ seed);
+                            seed = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[1], read_u64(slice, 88) ^ seed);
                         }
                     }
                 }
@@ -218,7 +219,7 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
     (a, b, seed, slice.len() as u64)
 }
 
-const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, secrets: &[u64; 7], data: &[u8]) -> (u64, u64, u64, u64) {
     let remainder;
     if data.len() <= 16 {
         if data.len() >= 4 {
@@ -246,11 +247,11 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
             let mut see4 = seed;
 
             while slice.len() > 80 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-                see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-                see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+                see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+                see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
                 let (_, split) = slice.split_at(80);
                 slice = split;
             }
@@ -262,13 +263,13 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
         }
 
         if slice.len() > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
             if slice.len() > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
                 if slice.len() > 48 {
-                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[1], read_u64(slice, 40) ^ seed);
+                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[1], read_u64(slice, 40) ^ seed);
                     if slice.len() > 64 {
-                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[1], read_u64(slice, 56) ^ seed);
+                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[1], read_u64(slice, 56) ^ seed);
                     }
                 }
             }
@@ -279,14 +280,14 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
         b ^= read_u64(data, data.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
     (a, b, seed, remainder)
 }
 
-const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, secrets: &[u64; 7], data: &[u8]) -> (u64, u64, u64, u64) {
     let remainder;
     if data.len() <= 16 {
         if data.len() >= 4 {
@@ -312,9 +313,9 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
             let mut see2 = seed;
 
             while slice.len() > 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
                 let (_, split) = slice.split_at(48);
                 slice = split;
             }
@@ -324,9 +325,9 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
         }
 
         if slice.len() > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
             if slice.len() > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             }
         }
 
@@ -335,7 +336,7 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
         b ^= read_u64(data, data.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
@@ -343,6 +344,6 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
 }
 
 #[inline(always)]
-pub(super) const fn rapidhash_finish<const PROTECTED: bool>(a: u64, b: u64, remainder: u64) -> u64 {
-    rapid_mix::<PROTECTED>(a ^ RAPID_SECRET[7], b ^ RAPID_SECRET[1] ^ remainder)
+pub(super) const fn rapidhash_finish<const PROTECTED: bool>(a: u64, b: u64, secrets: &[u64; 7], remainder: u64) -> u64 {
+    rapid_mix::<PROTECTED>(a ^ 0xaaaaaaaaaaaaaaaa, b ^ secrets[1] ^ remainder)
 }

--- a/rapidhash/src/v3/rapid_file.rs
+++ b/rapidhash/src/v3/rapid_file.rs
@@ -39,7 +39,7 @@ pub fn rapidhash_v3_file_inline<R: Read, const PROTECTED: bool>(data: R, mut see
     seed = rapidhash_seed(seed);
     let mut reader = ChunkedStreamReader::new(data, 16);
     let (a, b, _, remainder) = rapidhash_file_core::<R, PROTECTED>(0, 0, seed, &mut reader)?;
-    Ok(rapidhash_finish::<PROTECTED>(a, b, remainder))
+    Ok(rapidhash_finish::<PROTECTED>(a, b, &RAPID_SECRET, remainder))
 }
 
 #[inline(always)]
@@ -153,5 +153,5 @@ mod tests {
     use crate::v3::rapidhash_v3_inline;
     use super::*;
 
-    compare_rapidhash_file!(compare_rapidhash_v1_file, rapidhash_v3_inline::<false, false>, rapidhash_v3_file_inline::<_, false>);
+    compare_rapidhash_file!(compare_rapidhash_v1_file, rapidhash_v3_inline::<false, false>, rapidhash_v3_file_inline::<_, false>, &super::RAPID_SECRET);
 }


### PR DESCRIPTION
The secret parameters must be hidden from an end user to prevent trivial collisions. The persistent hash functions currently have no way to control override them, this PR aims to add them.

Need to think about how to recommend a user creates secrets. Setting secrets all to 0 would break the hash...

Sadly this is a breaking change, so would need to form part of a 3.0 release.