### PR TITLE
Portable seeding with `RapidSecrets` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 3.0.0 (20250725)
+## 3.0.0 (20250730)
 
+- **Breaking:** Add a `RapidSecrets` type for all versions to generate seeds and secrets for HashDoS-resistant hashing. This makes generating unique seeds/secrets easier for persistent hashing use cases.
 - **Breaking:** Replaced `FNV` with a `SPONGE` configuration with `RapidHasher` to improve integer and tuple hashing performance.
-- Perf: `RapidHasher` significantly improved performance hashing integers, tuples, and integer types.
+- **Breaking:** Fix the `rapidhash::v1` `V1_BUG` argument to actually match the original `v1.x.x` crate behaviour. The if statement was fundamentally wrong in the `v2.x.x` crate.
+- Perf: `RapidHasher` significantly improved performance hashing integers, tuples, and integer types using the new `SPONGE` configuration in both fast and quality modes.
 
 ## 2.0.2 (20250723)
 

--- a/rapidhash-bench/benches/bench/basic.rs
+++ b/rapidhash-bench/benches/bench/basic.rs
@@ -91,7 +91,7 @@ fn profile_bytes_raw<H: Fn(&[u8], u64) -> u64>(
             rand::rng().fill(slice.as_mut_slice());
             slice
         }, |bytes| {
-            black_box(hash(black_box(bytes), rapidhash::v1::RAPID_SEED))
+            black_box(hash(black_box(bytes), 0xbdd89aa982704029))  // using rapidhash V1 seed
         }, criterion::BatchSize::SmallInput);
     });
 }
@@ -125,7 +125,7 @@ pub fn bench(c: &mut Criterion) {
     bench_group::<highway::HighwayBuildHasher>(c, "hash/highwayhash");
     bench_group::<rustc_hash::FxBuildHasher>(c, "hash/rustc-hash");
 
-    bench_group_raw(c, "hash/rapidhash_raw", &rapidhash::v3::rapidhash_v3_seeded);
+    bench_group_raw(c, "hash/rapidhash_raw", &v3_bench);
     bench_group_raw(c, "hash/rapidhash_cc_v1", &rapidhash_c::rapidhashcc_v1);
     bench_group_raw(c, "hash/rapidhash_cc_v2", &rapidhash_c::rapidhashcc_v2);
     bench_group_raw(c, "hash/rapidhash_cc_v2_1", &rapidhash_c::rapidhashcc_v2_1);
@@ -133,4 +133,9 @@ pub fn bench(c: &mut Criterion) {
     bench_group_raw(c, "hash/rapidhash_cc_v3", &rapidhash_c::rapidhashcc_v3);
     bench_group_raw(c, "hash/rapidhash_cc_rs", &rapidhash_c::rapidhashcc_rs);
     bench_group_raw(c, "hash/wyhash_raw", &wyhash::wyhash);
+}
+
+fn v3_bench(data: &[u8], seed: u64) -> u64 {
+    let secrets = rapidhash::v3::RapidSecrets::seed_cpp(seed);
+    rapidhash::v3::rapidhash_v3_seeded(data, &secrets)
 }

--- a/rapidhash-bench/benches/bench/emails.rs
+++ b/rapidhash-bench/benches/bench/emails.rs
@@ -47,7 +47,7 @@ fn sample_emails(count: usize) -> Vec<String> {
     (0..count)
         .map(|_| {
             let length = index.sample(&mut rng);
-            
+
             Alphanumeric.sample_string(&mut rng, length)
         })
         .collect()
@@ -89,11 +89,16 @@ macro_rules! bench_hash_emails_raw {
     };
 }
 
+fn v3_bench(data: &[u8], seed: u64) -> u64 {
+    let secrets = rapidhash::v3::RapidSecrets::seed_cpp(seed);
+    rapidhash::v3::rapidhash_v3_seeded(data, &secrets)
+}
+
 bench_hash_emails!(bench_rapidhash, rapidhash::quality::RapidBuildHasher::default());
 bench_hash_emails_raw!(bench_rapidhash_cc_v1, rapidhash_c::rapidhashcc_v1);
 bench_hash_emails_raw!(bench_rapidhash_cc_v2, rapidhash_c::rapidhashcc_v2);
 bench_hash_emails_raw!(bench_rapidhash_cc_v3, rapidhash_c::rapidhashcc_v3);
-bench_hash_emails_raw!(bench_rapidhash_raw, rapidhash::v3::rapidhash_v3_seeded);
+bench_hash_emails_raw!(bench_rapidhash_raw, v3_bench);
 bench_hash_emails!(bench_default, std::hash::RandomState::default());
 bench_hash_emails!(bench_fxhash, fxhash::FxBuildHasher::default());
 bench_hash_emails!(bench_gxhash, gxhash::GxBuildHasher::default());

--- a/rapidhash/src/inner/mod.rs
+++ b/rapidhash/src/inner/mod.rs
@@ -32,7 +32,7 @@ mod collections;
 mod rapid_const;
 mod rapid_hasher;
 mod state;
-mod seeding;
+pub(crate) mod seeding;
 mod mix;
 
 #[doc(inline)]

--- a/rapidhash/src/main.rs
+++ b/rapidhash/src/main.rs
@@ -143,9 +143,9 @@ impl RapidhashVersion {
                 std::io::stdin().read_to_end(&mut buffer).expect("Could not read from stdin.");
 
                 if *protected {
-                    rapidhash::v1::rapidhash_v1_inline::<false, true, false>(&buffer, rapidhash::v1::RAPID_SEED)
+                    rapidhash::v1::rapidhash_v1_inline::<false, true, false>(&buffer, &rapidhash::v1::DEFAULT_RAPID_SECRETS)
                 } else {
-                    rapidhash::v1::rapidhash_v1_inline::<false, false, false>(&buffer, rapidhash::v1::RAPID_SEED)
+                    rapidhash::v1::rapidhash_v1_inline::<false, false, false>(&buffer, &rapidhash::v1::DEFAULT_RAPID_SECRETS)
                 }
             },
             RapidhashVersion::V2 { protected, version } => {
@@ -155,23 +155,23 @@ impl RapidhashVersion {
                 match version {
                     0 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_inline::<0, false, true>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<0, false, true>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         } else {
-                            rapidhash::v2::rapidhash_v2_inline::<0, false, false>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<0, false, false>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         }
                     }
                     1 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_inline::<1, false, true>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<1, false, true>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         } else {
-                            rapidhash::v2::rapidhash_v2_inline::<1, false, false>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<1, false, false>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         }
                     }
                     2 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_inline::<2, false, true>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<2, false, true>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         } else {
-                            rapidhash::v2::rapidhash_v2_inline::<2, false, false>(&buffer, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_inline::<2, false, false>(&buffer, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                         }
                     }
                     _ => {
@@ -181,10 +181,10 @@ impl RapidhashVersion {
             },
             RapidhashVersion::V3 { protected } => {
                 if *protected {
-                    rapidhash::v3::rapidhash_v3_file_inline::<_, true>(std::io::stdin(), rapidhash::v3::RAPID_SEED)
+                    rapidhash::v3::rapidhash_v3_file_inline::<_, true>(std::io::stdin(), &rapidhash::v3::DEFAULT_RAPID_SECRETS)
                         .expect("Could not read from stdin.")
                 } else {
-                    rapidhash::v3::rapidhash_v3_file_inline::<_, false>(std::io::stdin(), rapidhash::v3::RAPID_SEED)
+                    rapidhash::v3::rapidhash_v3_file_inline::<_, false>(std::io::stdin(), &rapidhash::v3::DEFAULT_RAPID_SECRETS)
                         .expect("Could not read from stdin.")
                 }
             },
@@ -195,10 +195,10 @@ impl RapidhashVersion {
         match self {
             RapidhashVersion::V1 { protected } => {
                 if *protected {
-                    rapidhash::v1::rapidhash_v1_file_inline::<true>(reader, rapidhash::v1::RAPID_SEED)
+                    rapidhash::v1::rapidhash_v1_file_inline::<true>(reader, &rapidhash::v1::DEFAULT_RAPID_SECRETS)
                         .expect("Failed to hash file.")
                 } else {
-                    rapidhash::v1::rapidhash_v1_file_inline::<false>(reader, rapidhash::v1::RAPID_SEED)
+                    rapidhash::v1::rapidhash_v1_file_inline::<false>(reader, &rapidhash::v1::DEFAULT_RAPID_SECRETS)
                         .expect("Failed to hash file.")
                 }
             },
@@ -206,28 +206,28 @@ impl RapidhashVersion {
                 match version {
                     0 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_file_inline::<0, true>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<0, true>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         } else {
-                            rapidhash::v2::rapidhash_v2_file_inline::<0, false>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<0, false>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         }
                     }
                     1 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_file_inline::<1, true>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<1, true>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         } else {
-                            rapidhash::v2::rapidhash_v2_file_inline::<1, false>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<1, false>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         }
                     }
                     2 => {
                         if *protected {
-                            rapidhash::v2::rapidhash_v2_file_inline::<2, true>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<2, true>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         } else {
-                            rapidhash::v2::rapidhash_v2_file_inline::<2, false>(reader, rapidhash::v2::RAPID_SEED)
+                            rapidhash::v2::rapidhash_v2_file_inline::<2, false>(reader, &rapidhash::v2::DEFAULT_RAPID_SECRETS)
                                 .expect("Failed to hash file.")
                         }
                     }
@@ -238,10 +238,10 @@ impl RapidhashVersion {
             },
             RapidhashVersion::V3 { protected} => {
                 if *protected {
-                    rapidhash::v3::rapidhash_v3_file_inline::<_, true>(reader, rapidhash::v3::RAPID_SEED)
+                    rapidhash::v3::rapidhash_v3_file_inline::<_, true>(reader, &rapidhash::v3::DEFAULT_RAPID_SECRETS)
                         .expect("Failed to hash file.")
                 } else {
-                    rapidhash::v3::rapidhash_v3_file_inline::<_, false>(reader, rapidhash::v3::RAPID_SEED)
+                    rapidhash::v3::rapidhash_v3_file_inline::<_, false>(reader, &rapidhash::v3::DEFAULT_RAPID_SECRETS)
                         .expect("Failed to hash file.")
                 }
             },

--- a/rapidhash/src/v1/mod.rs
+++ b/rapidhash/src/v1/mod.rs
@@ -1,14 +1,18 @@
 //! Portable hashing: rapidhash V1 algorithm.
+//!
+//! For new code, please use [`rapidhash::v3`] instead, as it is a superior hashing algorithm.
 
 mod rapid_const;
 #[cfg(any(feature = "std", docsrs))]
 mod rapid_file;
+mod seed;
 
 #[doc(inline)]
 pub use rapid_const::*;
 #[doc(inline)]
 #[cfg(any(feature = "std", docsrs))]
 pub use rapid_file::*;
+pub use seed::*;
 
 #[cfg(test)]
 mod tests {
@@ -18,5 +22,22 @@ mod tests {
     use super::*;
 
     flip_bit_trial!(flip_bit_trial_v1, rapidhash_v1_inline::<false, false, false>);
+    flip_bit_trial!(flip_bit_trial_v1_bug, rapidhash_v1_inline::<false, false, true>);
     compare_to_c!(compare_to_c_v1, rapidhash_v1_inline::<false, false, false>, rapidhash_v1_inline::<true, false, false>, rapidhashcc_v1);
+
+    #[test]
+    fn test_v1_bug() {
+        fn rapidhash_bug(data: &str) -> u64 {
+            rapidhash_v1_inline::<false, false, true>(data.as_bytes(), &DEFAULT_RAPID_SECRETS)
+        }
+
+        // The v1.x.x bug was for the 48-byte case
+        // The v2.x.x attempted fix ended up not hashing a bunch of data beyond 48 bytes... :facepalm:
+        assert_eq!(5006746792674864303, rapidhash_bug("\n"));
+        assert_eq!(4933522537766704430, rapidhash_bug("abcdef\n"));
+        assert_eq!(3345456103814863532, rapidhash_bug("abcdefghijklmnopqrstuvwxyz12345678901234567890\n"));
+        assert_eq!(8825074939507110130, rapidhash_bug("abcdefghijklmnopqrstuvwxyz123456789012345678901\n"));
+        assert_eq!(2762901732509801681, rapidhash_bug("abcdefghijklmnopqrstuvwxyz1234567890123456789012\n"));
+        assert_eq!( 934306286158757431, rapidhash_bug("abcdefghijklmnopqrstuvwxyz12345678901234567890123\n"));
+    }
 }

--- a/rapidhash/src/v1/rapid_const.rs
+++ b/rapidhash/src/v1/rapid_const.rs
@@ -34,7 +34,7 @@ pub const fn rapidhash_v1_inline<const COMPACT: bool, const PROTECTED: bool, con
 
 #[inline(always)]
 pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool, const V1_BUG: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64) {
-    let mut seed = rapid_secrets.seed;
+    let mut seed = rapid_secrets.seed ^ data.len() as u64;
     let secrets = &rapid_secrets.secrets;
 
     if data.len() <= 16 {

--- a/rapidhash/src/v1/rapid_file.rs
+++ b/rapidhash/src/v1/rapid_file.rs
@@ -44,7 +44,7 @@ pub fn rapidhash_v1_file_inline<const PROTECTED: bool>(data: &mut File, secrets:
 
 #[inline(always)]
 fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, len: usize, iter: &mut BufReader<&mut File>) -> std::io::Result<(u64, u64, u64)> {
-    let mut seed = rapid_secrets.seed;
+    let mut seed = rapid_secrets.seed ^ len as u64;
     let secrets = &rapid_secrets.secrets;
 
     if len <= 16 {

--- a/rapidhash/src/v1/rapid_file.rs
+++ b/rapidhash/src/v1/rapid_file.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use crate::util::mix::{rapid_mix, rapid_mum};
 use crate::util::read::{read_u32_combined, read_u64};
-use crate::v1::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidhash_seed};
+use super::{DEFAULT_RAPID_SECRETS, RapidSecrets, rapidhash_finish};
 
 /// Rapidhash a file, matching the C++ implementation.
 ///
@@ -10,7 +10,7 @@ use crate::v1::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidha
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
 pub fn rapidhash_v1_file(data: &mut File) -> std::io::Result<u64> {
-    rapidhash_v1_file_inline::<false>(data, RAPID_SEED)
+    rapidhash_v1_file_inline::<false>(data, &DEFAULT_RAPID_SECRETS)
 }
 
 /// Rapidhash a file, matching the C++ implementation, with a custom seed.
@@ -18,8 +18,8 @@ pub fn rapidhash_v1_file(data: &mut File) -> std::io::Result<u64> {
 /// This method will check the metadata for a file length, and then stream the file with a
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
-pub fn rapidhash_v1_file_seeded(data: &mut File, seed: u64) -> std::io::Result<u64> {
-    rapidhash_v1_file_inline::<false>(data, seed)
+pub fn rapidhash_v1_file_seeded(data: &mut File, secrets: &RapidSecrets) -> std::io::Result<u64> {
+    rapidhash_v1_file_inline::<false>(data, secrets)
 }
 
 /// Rapidhash a file, matching the C++ implementation.
@@ -35,16 +35,18 @@ pub fn rapidhash_v1_file_seeded(data: &mut File, seed: u64) -> std::io::Result<u
 /// Is marked with `#[inline(always)]` to force the compiler to inline and optimise the method.
 /// Can provide large performance uplifts for inputs where the length is known at compile time.
 #[inline(always)]
-pub fn rapidhash_v1_file_inline<const PROTECTED: bool>(data: &mut File, mut seed: u64) -> std::io::Result<u64> {
+pub fn rapidhash_v1_file_inline<const PROTECTED: bool>(data: &mut File, secrets: &RapidSecrets) -> std::io::Result<u64> {
     let len = data.metadata()?.len();
     let mut reader = BufReader::new(data);
-    seed = rapidhash_seed(seed) ^ len;
-    let (a, b, _) = rapidhash_file_core::<PROTECTED>(0, 0, seed, len as usize, &mut reader)?;
-    Ok(rapidhash_finish::<PROTECTED>(a, b, len))
+    let (a, b, _) = rapidhash_file_core::<PROTECTED>(0, 0, secrets, len as usize, &mut reader)?;
+    Ok(rapidhash_finish::<PROTECTED>(a, b, len, secrets))
 }
 
 #[inline(always)]
-fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, len: usize, iter: &mut BufReader<&mut File>) -> std::io::Result<(u64, u64, u64)> {
+fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, len: usize, iter: &mut BufReader<&mut File>) -> std::io::Result<(u64, u64, u64)> {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
+
     if len <= 16 {
         let mut data = [0u8; 16];
         iter.read_exact(&mut data[0..len])?;
@@ -87,12 +89,12 @@ fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: 
             while remaining >= 96 {
                 // read into and process using the first half of the buffer
                 iter.read_exact(slice)?;
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[0], read_u64(slice, 56) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[1], read_u64(slice, 72) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[2], read_u64(slice, 88) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[0], read_u64(slice, 56) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[1], read_u64(slice, 72) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[2], read_u64(slice, 88) ^ see2);
                 remaining -= 96;
             }
 
@@ -103,9 +105,9 @@ fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: 
             end = 96 + remaining;
 
             if remaining >= 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
                 slice = &mut buf[96 + 48..96 + remaining];
                 remaining -= 48;
             }
@@ -118,9 +120,9 @@ fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: 
         }
 
         if remaining > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed ^ RAPID_SECRET[1]);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed ^ secrets[1]);
             if remaining > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             }
         }
 
@@ -128,7 +130,7 @@ fn rapidhash_file_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: 
         b ^= read_u64(&buf, end - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);

--- a/rapidhash/src/v1/seed.rs
+++ b/rapidhash/src/v1/seed.rs
@@ -1,0 +1,126 @@
+//! Reliable seeding and secrets generation for the hash functions.
+
+use crate::util::mix::rapid_mix;
+
+/// The default seed used in the C++ implementation.
+pub(crate) const DEFAULT_SEED: u64 = 0xbdd89aa982704029;
+
+/// Used only for generating random secrets.
+const DEFAULT_SECRETS: [u64; 3] = [
+    0x2d358dccaa6c78a5,
+    0x8bb84b93962eacc9,
+    0x4b33a62ed433d4a3,
+];
+
+/// The default rapidhash secrets used in the C++ implementation.
+///
+/// We recommend generating your own secrets using the [`crate::v3::RapidSecrets::seed`] method to avoid
+/// trivial collision attacks if you need minimal HashDoS protection.
+pub const DEFAULT_RAPID_SECRETS: RapidSecrets = RapidSecrets::seed_cpp(DEFAULT_SEED);
+
+/// Hold the seed and secrets to be used by rapidhash.
+///
+/// RapidSecrets premix the seed and generate a set of other secrets based on the seed that are all
+/// used in the hashing process. There are some quality checks on the random values to ensure a
+/// reasonable distribution of entropy in the generated secrets.
+///
+/// Constructing this struct is fairly cheap, but unnecessary in the critical path. We therefore
+/// recommend instantiating it once and re-using the same instance for any persistent hashing. The
+/// `seed` method is marked `const` to also do so at compile time.
+///
+/// # Minimal HashDoS Protection
+/// We recommend changing the default seed and secrets must be changed to avoid trivial collision
+/// attacks. For persistent hashing, you can hard code your own randomised seed at compile time.
+///
+/// ```rust
+/// use rapidhash::v1::RapidSecrets;
+/// const DEFAULT_SECRETS: RapidSecrets = RapidSecrets::seed(0x123456);  // <-- change this value!
+///
+/// /// Export your chosen rapidhash version and secrets for use throughout your project.
+/// pub fn rapidhash(data: &[u8]) -> u64 {
+///     rapidhash::v1::rapidhash_v1_seeded(data, &DEFAULT_SECRETS)
+/// }
+/// ```
+///
+/// TODO: serde or serialization support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RapidSecrets {
+    /// The core rapidhash seed.
+    pub seed: u64,
+
+    /// The secrets, effectively other seeds used in the hashing process.
+    pub secrets: [u64; 3],
+}
+
+impl RapidSecrets {
+    /// Generate secrets from a given randomised seed.
+    ///
+    /// Note the chosen seed will be pre-mixed to further randomise it, and the secrets will be
+    /// computed based on the seed.
+    ///
+    /// If compatibility with the C++ implementation is required, use the `seed_cpp` method instead.
+    #[inline]
+    pub const fn seed(seed: u64) -> Self {
+        let seed = premix_seed(seed, 0);
+        let mut secrets = [0; 3];
+        secrets[0] = premix_seed(seed, 0);
+        secrets[1] = premix_seed(secrets[0], 1);
+        secrets[2] = premix_seed(secrets[1], 2);
+        Self { seed, secrets }
+    }
+
+    /// Creates a new `RapidSecrets` instance with a different seed and the same secrets.
+    ///
+    /// This is useful for in-memory hashing, so we can quickly use a different seed for other
+    /// HashMaps.
+    #[inline]
+    pub const fn reseed(&self) -> Self {
+        Self {
+            seed: premix_seed(self.seed, 6),
+            secrets: self.secrets,
+        }
+    }
+
+    /// Creates a new `RapidSecrets` instance using a seed and secrets that are compatible with the
+    /// C++ implementation.
+    ///
+    /// Note that these **use the default secrets** and therefore are liable to some trivial
+    /// collision attacks, as randomising both the seed and secrets is necessary to provide minimal
+    /// HashDoS resistance.
+    #[inline]
+    pub const fn seed_cpp(seed: u64) -> Self {
+        Self {
+            seed: rapidhash_seed(seed),
+            secrets: DEFAULT_SECRETS,
+        }
+    }
+}
+
+#[inline(always)]
+const fn rapidhash_seed(seed: u64) -> u64 {
+    seed ^ rapid_mix::<false>(seed ^ DEFAULT_SECRETS[0], DEFAULT_SECRETS[1])
+}
+
+#[inline]
+const fn premix_seed(mut seed: u64, i: usize) -> u64 {
+    seed ^= rapid_mix::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[i]);
+
+    // ensure the seeds are of reasonable non-zero quality
+    const HI: u64 = 0xFFFF << 48;
+    const MI: u64 = 0xFFFF << 24;
+    const LO: u64 = 0xFFFF;
+
+    if (seed & HI) == 0 {
+        seed |= 1u64 << 63;
+    }
+
+    if (seed & MI) == 0 {
+        seed |= 1u64 << 31;
+    }
+
+    if (seed & LO) == 0 {
+        seed |= 1u64;
+    }
+
+    seed
+}

--- a/rapidhash/src/v2/mod.rs
+++ b/rapidhash/src/v2/mod.rs
@@ -1,14 +1,18 @@
 //! Portable hashing: rapidhash V2.2 algorithm.
+//!
+//! For new code, please use [`rapidhash::v3`] instead, as it is a superior hashing algorithm.
 
 mod rapid_const;
 #[cfg(any(feature = "std", docsrs))]
 mod rapid_file;
+mod seed;
 
 #[doc(inline)]
 pub use rapid_const::*;
 #[doc(inline)]
 #[cfg(any(feature = "std", docsrs))]
 pub use rapid_file::*;
+pub use seed::*;
 
 #[cfg(test)]
 mod tests {

--- a/rapidhash/src/v2/rapid_const.rs
+++ b/rapidhash/src/v2/rapid_const.rs
@@ -52,6 +52,7 @@ pub(super) const fn rapidhash_core<const MINOR: u8, const COMPACT: bool, const P
     let secrets = &rapid_secrets.secrets;
 
     if data.len() <= 16 {
+        seed ^= data.len() as u64;
         if data.len() >= 4 {
             if data.len() >= 8 {
                 let plast = data.len() - 8;
@@ -86,7 +87,7 @@ pub(super) const fn rapidhash_core<const MINOR: u8, const COMPACT: bool, const P
 
 #[inline]  // intentionally not always
 const fn rapidhash_core_17_64<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64) {
-    let mut seed = rapid_secrets.seed;
+    let mut seed = rapid_secrets.seed ^ data.len() as u64;
     let secrets = &rapid_secrets.secrets;
     let slice = data;
 
@@ -111,7 +112,7 @@ const fn rapidhash_core_17_64<const MINOR: u8, const PROTECTED: bool>(mut a: u64
 #[cold]
 #[inline(never)]
 const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64) {
-    let mut seed = rapid_secrets.seed;
+    let mut seed = rapid_secrets.seed ^ data.len() as u64;
     let secrets = &rapid_secrets.secrets;
 
     let mut slice = data;

--- a/rapidhash/src/v2/rapid_file.rs
+++ b/rapidhash/src/v2/rapid_file.rs
@@ -57,7 +57,7 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
         panic!("rapidhash_file_core does not support minor version {}. Supported versions are 0, 1, and 2.", MINOR);
     }
 
-    let mut seed = rapid_secrets.seed;
+    let mut seed = rapid_secrets.seed ^ len as u64;
     let secrets = &rapid_secrets.secrets;
 
     if len <= 16 {

--- a/rapidhash/src/v2/rapid_file.rs
+++ b/rapidhash/src/v2/rapid_file.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use crate::util::mix::{rapid_mix, rapid_mum};
 use crate::util::read::{read_u32, read_u64};
-use crate::v2::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidhash_seed};
+use super::{DEFAULT_RAPID_SECRETS, RapidSecrets, rapidhash_finish};
 
 /// Rapidhash V2.2 a file, matching the C++ implementation.
 ///
@@ -12,7 +12,7 @@ use crate::v2::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidha
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
 pub fn rapidhash_v2_2_file(data: &mut File) -> std::io::Result<u64> {
-    rapidhash_v2_file_inline::<2, false>(data, RAPID_SEED)
+    rapidhash_v2_file_inline::<2, false>(data, &DEFAULT_RAPID_SECRETS)
 }
 
 /// Rapidhash V2.2 a file, matching the C++ implementation, with a custom seed.
@@ -22,8 +22,8 @@ pub fn rapidhash_v2_2_file(data: &mut File) -> std::io::Result<u64> {
 /// This method will check the metadata for a file length, and then stream the file with a
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
-pub fn rapidhash_v2_2_file_seeded(data: &mut File, seed: u64) -> std::io::Result<u64> {
-    rapidhash_v2_file_inline::<2, false>(data, seed)
+pub fn rapidhash_v2_2_file_seeded(data: &mut File, secrets: &RapidSecrets) -> std::io::Result<u64> {
+    rapidhash_v2_file_inline::<2, false>(data, secrets)
 }
 
 /// Rapidhash V2 a file, matching the C++ implementation. (2.0, 2.1, and 2.2 supported)
@@ -44,19 +44,21 @@ pub fn rapidhash_v2_2_file_seeded(data: &mut File, seed: u64) -> std::io::Result
 /// - 1: v2.1
 /// - 2: v2.2
 #[inline(always)]
-pub fn rapidhash_v2_file_inline<const MINOR: u8, const PROTECTED: bool>(data: &mut File, mut seed: u64) -> std::io::Result<u64> {
+pub fn rapidhash_v2_file_inline<const MINOR: u8, const PROTECTED: bool>(data: &mut File, secrets: &RapidSecrets) -> std::io::Result<u64> {
     let len = data.metadata()?.len();
     let mut reader = BufReader::new(data);
-    seed = rapidhash_seed(seed) ^ len;
-    let (a, b, _) = rapidhash_file_core::<MINOR, PROTECTED>(0, 0, seed, len as usize, &mut reader)?;
-    Ok(rapidhash_finish::<PROTECTED>(a, b, len))
+    let (a, b, _) = rapidhash_file_core::<MINOR, PROTECTED>(0, 0, secrets, len as usize, &mut reader)?;
+    Ok(rapidhash_finish::<PROTECTED>(a, b, len, secrets))
 }
 
 #[inline(always)]
-fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, len: usize, iter: &mut BufReader<&mut File>) -> std::io::Result<(u64, u64, u64)> {
+fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, len: usize, iter: &mut BufReader<&mut File>) -> std::io::Result<(u64, u64, u64)> {
     if MINOR > 2 {
         panic!("rapidhash_file_core does not support minor version {}. Supported versions are 0, 1, and 2.", MINOR);
     }
+
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
 
     if len <= 16 {
         let mut buf = [0u8; 16];
@@ -101,21 +103,21 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
             // read into and process using the first half of the buffer
             iter.read_exact(slice)?;
 
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
 
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ RAPID_SECRET[0], read_u64(slice, 120) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ RAPID_SECRET[1], read_u64(slice, 136) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ RAPID_SECRET[2], read_u64(slice, 152) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ RAPID_SECRET[3], read_u64(slice, 168) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ RAPID_SECRET[4], read_u64(slice, 184) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ RAPID_SECRET[5], read_u64(slice, 200) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ RAPID_SECRET[6], read_u64(slice, 216) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ secrets[0], read_u64(slice, 120) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ secrets[1], read_u64(slice, 136) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ secrets[2], read_u64(slice, 152) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ secrets[3], read_u64(slice, 168) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ secrets[4], read_u64(slice, 184) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ secrets[5], read_u64(slice, 200) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ secrets[6], read_u64(slice, 216) ^ see6);
 
             remaining -= 224;
         }
@@ -127,28 +129,28 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
         let end = 224 + remaining;
 
         if slice.len() >= 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
             slice = &mut slice[112..remaining];
             remaining -= 112;
         }
 
         if remaining >= 48 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
             slice = &mut slice[48..remaining];
             remaining -= 48;
 
             if remaining >= 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
                 slice = &mut slice[48..remaining];
                 remaining -= 48;
             }
@@ -162,9 +164,9 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
         seed ^= see3;
 
         if remaining > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
             if remaining > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             }
         }
 
@@ -175,12 +177,12 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
         iter.read_exact(&mut data[0..len])?;
         let slice = &data[..len];
 
-        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
+        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
         if slice.len() > 32 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ seed);
             if slice.len() > 48 {
                 let index: usize = if MINOR < 2 { 0 } else { 1 };
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[index], read_u64(slice, 40) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[index], read_u64(slice, 40) ^ seed);
             }
         }
 
@@ -188,7 +190,7 @@ fn rapidhash_file_core<const MINOR: u8, const PROTECTED: bool>(mut a: u64, mut b
         b = read_u64(slice, slice.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);

--- a/rapidhash/src/v2/seed.rs
+++ b/rapidhash/src/v2/seed.rs
@@ -1,0 +1,133 @@
+//! Reliable seeding and secrets generation for the hash functions.
+
+use crate::util::mix::rapid_mix;
+
+/// The default seed used in the C++ implementation.
+pub(crate) const DEFAULT_SEED: u64 = 0;
+
+/// Used only for generating random secrets.
+const DEFAULT_SECRETS: [u64; 7] = [
+    0x2d358dccaa6c78a5,
+    0x8bb84b93962eacc9,
+    0x4b33a62ed433d4a3,
+    0x4d5a2da51de1aa47,
+    0xa0761d6478bd642f,
+    0xe7037ed1a0b428db,
+    0x90ed1765281c388c,
+];
+
+/// The default rapidhash secrets used in the C++ implementation.
+///
+/// We recommend generating your own secrets using the [`crate::v3::RapidSecrets::seed`] method to avoid
+/// trivial collision attacks if you need minimal HashDoS protection.
+pub const DEFAULT_RAPID_SECRETS: RapidSecrets = RapidSecrets::seed_cpp(DEFAULT_SEED);
+
+/// Hold the seed and secrets to be used by rapidhash.
+///
+/// RapidSecrets premix the seed and generate a set of other secrets based on the seed that are all
+/// used in the hashing process. There are some quality checks on the random values to ensure a
+/// reasonable distribution of entropy in the generated secrets.
+///
+/// Constructing this struct is fairly cheap, but unnecessary in the critical path. We therefore
+/// recommend instantiating it once and re-using the same instance for any persistent hashing. The
+/// `seed` method is marked `const` to also do so at compile time.
+///
+/// # Minimal HashDoS Protection
+/// We recommend changing the default seed and secrets must be changed to avoid trivial collision
+/// attacks. For persistent hashing, you can hard code your own randomised seed at compile time.
+///
+/// ```rust
+/// use rapidhash::v2::RapidSecrets;
+/// const DEFAULT_SECRETS: RapidSecrets = RapidSecrets::seed(0x123456);  // <-- change this value!
+///
+/// /// Export your chosen rapidhash version and secrets for use throughout your project.
+/// pub fn rapidhash(data: &[u8]) -> u64 {
+///     rapidhash::v2::rapidhash_v2_2_seeded(data, &DEFAULT_SECRETS)
+/// }
+/// ```
+///
+/// TODO: serde or serialization support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RapidSecrets {
+    /// The core rapidhash seed.
+    pub seed: u64,
+
+    /// The secrets, effectively other seeds used in the hashing process.
+    pub secrets: [u64; 7],
+}
+
+impl RapidSecrets {
+    /// Generate secrets from a given randomised seed.
+    ///
+    /// Note the chosen seed will be pre-mixed to further randomise it, and the secrets will be
+    /// computed based on the seed.
+    ///
+    /// If compatibility with the C++ implementation is required, use the `seed_cpp` method instead.
+    #[inline]
+    pub const fn seed(seed: u64) -> Self {
+        let seed = premix_seed(seed, 0);
+        let mut secrets = [0; 7];
+        secrets[0] = premix_seed(seed, 0);
+        secrets[1] = premix_seed(secrets[0], 1);
+        secrets[2] = premix_seed(secrets[1], 2);
+        secrets[3] = premix_seed(secrets[2], 3);
+        secrets[4] = premix_seed(secrets[3], 4);
+        secrets[5] = premix_seed(secrets[4], 5);
+        secrets[6] = premix_seed(secrets[5], 6);
+        Self { seed, secrets }
+    }
+
+    /// Creates a new `RapidSecrets` instance with a different seed and the same secrets.
+    ///
+    /// This is useful for in-memory hashing, so we can quickly use a different seed for other
+    /// HashMaps.
+    #[inline]
+    pub const fn reseed(&self) -> Self {
+        Self {
+            seed: premix_seed(self.seed, 6),
+            secrets: self.secrets,
+        }
+    }
+
+    /// Creates a new `RapidSecrets` instance using a seed and secrets that are compatible with the
+    /// C++ implementation.
+    ///
+    /// Note that these **use the default secrets** and therefore are liable to some trivial
+    /// collision attacks, as randomising both the seed and secrets is necessary to provide minimal
+    /// HashDoS resistance.
+    #[inline]
+    pub const fn seed_cpp(seed: u64) -> Self {
+        Self {
+            seed: rapidhash_seed(seed),
+            secrets: DEFAULT_SECRETS,
+        }
+    }
+}
+
+const fn rapidhash_seed(seed: u64) -> u64 {
+    seed ^ rapid_mix::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[1])
+}
+
+#[inline]
+const fn premix_seed(mut seed: u64, i: usize) -> u64 {
+    seed ^= rapid_mix::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[i]);
+
+    // ensure the seeds are of reasonable non-zero quality
+    const HI: u64 = 0xFFFF << 48;
+    const MI: u64 = 0xFFFF << 24;
+    const LO: u64 = 0xFFFF;
+
+    if (seed & HI) == 0 {
+        seed |= 1u64 << 63;
+    }
+
+    if (seed & MI) == 0 {
+        seed |= 1u64 << 31;
+    }
+
+    if (seed & LO) == 0 {
+        seed |= 1u64;
+    }
+
+    seed
+}

--- a/rapidhash/src/v3/mod.rs
+++ b/rapidhash/src/v3/mod.rs
@@ -3,6 +3,7 @@
 mod rapid_const;
 #[cfg(any(feature = "std", docsrs))]
 mod rapid_file;
+mod seed;
 
 #[doc(inline)]
 pub use rapid_const::*;
@@ -10,6 +11,8 @@ pub use rapid_const::*;
 #[doc(inline)]
 #[cfg(any(feature = "std", docsrs))]
 pub use rapid_file::*;
+
+pub use seed::*;
 
 #[cfg(test)]
 mod tests {

--- a/rapidhash/src/v3/rapid_const.rs
+++ b/rapidhash/src/v3/rapid_const.rs
@@ -1,35 +1,21 @@
 use crate::util::mix::{rapid_mix, rapid_mum};
 use crate::util::read::{read_u32, read_u64};
-
-/// The rapidhash default seed.
-pub const RAPID_SEED: u64 = 0;
-
-/// Rapidhash secret parameters.
-pub(super) const RAPID_SECRET: [u64; 8] = [
-    0x2d358dccaa6c78a5,
-    0x8bb84b93962eacc9,
-    0x4b33a62ed433d4a3,
-    0x4d5a2da51de1aa47,
-    0xa0761d6478bd642f,
-    0xe7037ed1a0b428db,
-    0x90ed1765281c388c,
-    0xaaaaaaaaaaaaaaaa,
-];
+use super::{DEFAULT_RAPID_SECRETS, RapidSecrets};
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation, with the default seed.
 ///
 /// Fixed length inputs will greatly benefit from inlining with [rapidhash_inline] instead.
 #[inline]
 pub const fn rapidhash_v3(data: &[u8]) -> u64 {
-    rapidhash_v3_inline::<false, false>(data, RAPID_SEED)
+    rapidhash_v3_inline::<false, false>(data, &DEFAULT_RAPID_SECRETS)
 }
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation, with a custom seed.
 ///
 /// Fixed length inputs will greatly benefit from inlining with [rapidhash_inline] instead.
 #[inline]
-pub const fn rapidhash_v3_seeded(data: &[u8], seed: u64) -> u64 {
-    rapidhash_v3_inline::<false, false>(data, seed)
+pub const fn rapidhash_v3_seeded(data: &[u8], secrets: &RapidSecrets) -> u64 {
+    rapidhash_v3_inline::<false, false>(data, secrets)
 }
 
 /// Rapidhash V3 a single byte stream, matching the C++ implementation.
@@ -47,10 +33,9 @@ pub const fn rapidhash_v3_seeded(data: &[u8], seed: u64) -> u64 {
 /// user-controlled secret values. There is a trivial collision attack at certain input sizes (such
 /// as 32 bytes) that can be exploited when an attacker knows the secret values.
 #[inline(always)]
-pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
-    seed = rapidhash_seed(seed);
-    let (a, b, _, remainder) = rapidhash_core::<COMPACT, PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(data: &[u8], secrets: &RapidSecrets) -> u64 {
+    let (a, b, _, remainder) = rapidhash_core::<COMPACT, PROTECTED>(0, 0, secrets, data);
+    rapidhash_finish::<PROTECTED>(a, b, remainder, secrets)
 }
 
 /// Rapidhash V3 Micro, a very compact version of the rapidhash algorithm.
@@ -65,10 +50,9 @@ pub const fn rapidhash_v3_inline<const COMPACT: bool, const PROTECTED: bool>(dat
 /// - `PROTECTED`: Slightly stronger hash quality and DoS resistance by performing two extra XOR
 ///     instructions on every mix step. Disabled by default.
 #[inline(always)]
-pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
-    seed = rapidhash_seed(seed);
+pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], seed: &RapidSecrets) -> u64 {
     let (a, b, _, remainder) = rapidhash_micro_core::<PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+    rapidhash_finish::<PROTECTED>(a, b, remainder, seed)
 }
 
 /// Rapidhash V3 Nano, a very compact version of the rapidhash algorithm.
@@ -84,19 +68,16 @@ pub const fn rapidhash_v3_micro_inline<const PROTECTED: bool>(data: &[u8], mut s
 /// - `PROTECTED`: Slightly stronger hash quality and DoS resistance by performing two extra XOR
 ///     instructions on every mix step. Disabled by default.
 #[inline(always)]
-pub const fn rapidhash_v3_nano_inline<const PROTECTED: bool>(data: &[u8], mut seed: u64) -> u64 {
-    seed = rapidhash_seed(seed);
+pub const fn rapidhash_v3_nano_inline<const PROTECTED: bool>(data: &[u8], seed: &RapidSecrets) -> u64 {
     let (a, b, _, remainder) = rapidhash_nano_core::<PROTECTED>(0, 0, seed, data);
-    rapidhash_finish::<PROTECTED>(a, b, remainder)
+    rapidhash_finish::<PROTECTED>(a, b, remainder, seed)
 }
 
 #[inline(always)]
-pub(super) const fn rapidhash_seed(seed: u64) -> u64 {
-    seed ^ rapid_mix::<false>(seed ^ RAPID_SECRET[2], RAPID_SECRET[1])
-}
+pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64, u64) {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
 
-#[inline(always)]
-pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
     // TODO: benchmark without the a,b XOR -- eg. a oneshot
     let remainder;
     if data.len() <= 16 {
@@ -117,10 +98,10 @@ pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(m
         }
         remainder = data.len() as u64;
     } else {
-        (a, b, seed, remainder) = rapidhash_core_cold::<COMPACT, PROTECTED>(a, b, seed, data);
+        (a, b, seed, remainder) = rapidhash_core_cold::<COMPACT, PROTECTED>(a, b, rapid_secrets, data);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
@@ -128,7 +109,10 @@ pub(super) const fn rapidhash_core<const COMPACT: bool, const PROTECTED: bool>(m
 }
 
 #[inline]
-const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64, u64) {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
+
     let mut slice = data;
 
     // most CPUs appear to benefit from this unrolled loop
@@ -141,46 +125,46 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
 
     if !COMPACT {
         while slice.len() > 224 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
 
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ RAPID_SECRET[0], read_u64(slice, 120) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ RAPID_SECRET[1], read_u64(slice, 136) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ RAPID_SECRET[2], read_u64(slice, 152) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ RAPID_SECRET[3], read_u64(slice, 168) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ RAPID_SECRET[4], read_u64(slice, 184) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ RAPID_SECRET[5], read_u64(slice, 200) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ RAPID_SECRET[6], read_u64(slice, 216) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 112) ^ secrets[0], read_u64(slice, 120) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 128) ^ secrets[1], read_u64(slice, 136) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 144) ^ secrets[2], read_u64(slice, 152) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 160) ^ secrets[3], read_u64(slice, 168) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 176) ^ secrets[4], read_u64(slice, 184) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 192) ^ secrets[5], read_u64(slice, 200) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 208) ^ secrets[6], read_u64(slice, 216) ^ see6);
 
             let (_, split) = slice.split_at(224);
             slice = split;
         }
 
         if slice.len() > 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
             let (_, split) = slice.split_at(112);
             slice = split;
         }
     } else {
         while slice.len() > 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[5], read_u64(slice, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ RAPID_SECRET[6], read_u64(slice, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[5], read_u64(slice, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(slice, 96) ^ secrets[6], read_u64(slice, 104) ^ see6);
             let (_, split) = slice.split_at(112);
             slice = split;
         }
@@ -194,17 +178,17 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
     seed ^= see2;
 
     if slice.len() > 16 {
-        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+        seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
         if slice.len() > 32 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             if slice.len() > 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[1], read_u64(slice, 40) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[1], read_u64(slice, 40) ^ seed);
                 if slice.len() > 64 {
-                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[1], read_u64(slice, 56) ^ seed);
+                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[1], read_u64(slice, 56) ^ seed);
                     if slice.len() > 80 {
-                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[2], read_u64(slice, 72) ^ seed);
+                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[2], read_u64(slice, 72) ^ seed);
                         if slice.len() > 96 {
-                            seed = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ RAPID_SECRET[1], read_u64(slice, 88) ^ seed);
+                            seed = rapid_mix::<PROTECTED>(read_u64(slice, 80) ^ secrets[1], read_u64(slice, 88) ^ seed);
                         }
                     }
                 }
@@ -218,7 +202,10 @@ const fn rapidhash_core_cold<const COMPACT: bool, const PROTECTED: bool>(mut a: 
     (a, b, seed, slice.len() as u64)
 }
 
-const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64, u64) {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
+
     let remainder;
     if data.len() <= 16 {
         if data.len() >= 4 {
@@ -246,11 +233,11 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
             let mut see4 = seed;
 
             while slice.len() > 80 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
-                see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[3], read_u64(slice, 56) ^ see3);
-                see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ RAPID_SECRET[4], read_u64(slice, 72) ^ see4);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
+                see3 = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[3], read_u64(slice, 56) ^ see3);
+                see4 = rapid_mix::<PROTECTED>(read_u64(slice, 64) ^ secrets[4], read_u64(slice, 72) ^ see4);
                 let (_, split) = slice.split_at(80);
                 slice = split;
             }
@@ -262,13 +249,13 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
         }
 
         if slice.len() > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
             if slice.len() > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
                 if slice.len() > 48 {
-                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[1], read_u64(slice, 40) ^ seed);
+                    seed = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[1], read_u64(slice, 40) ^ seed);
                     if slice.len() > 64 {
-                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ RAPID_SECRET[1], read_u64(slice, 56) ^ seed);
+                        seed = rapid_mix::<PROTECTED>(read_u64(slice, 48) ^ secrets[1], read_u64(slice, 56) ^ seed);
                     }
                 }
             }
@@ -279,14 +266,17 @@ const fn rapidhash_micro_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut
         b ^= read_u64(data, data.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
     (a, b, seed, remainder)
 }
 
-const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, data: &[u8]) -> (u64, u64, u64, u64) {
+const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, data: &[u8]) -> (u64, u64, u64, u64) {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
+
     let remainder;
     if data.len() <= 16 {
         if data.len() >= 4 {
@@ -312,9 +302,9 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
             let mut see2 = seed;
 
             while slice.len() > 48 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[0], read_u64(slice, 8) ^ seed);
-                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[1], read_u64(slice, 24) ^ see1);
-                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ RAPID_SECRET[2], read_u64(slice, 40) ^ see2);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[0], read_u64(slice, 8) ^ seed);
+                see1 = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[1], read_u64(slice, 24) ^ see1);
+                see2 = rapid_mix::<PROTECTED>(read_u64(slice, 32) ^ secrets[2], read_u64(slice, 40) ^ see2);
                 let (_, split) = slice.split_at(48);
                 slice = split;
             }
@@ -324,9 +314,9 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
         }
 
         if slice.len() > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ RAPID_SECRET[2], read_u64(slice, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(slice, 0) ^ secrets[2], read_u64(slice, 8) ^ seed);
             if slice.len() > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ RAPID_SECRET[2], read_u64(slice, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(slice, 16) ^ secrets[2], read_u64(slice, 24) ^ seed);
             }
         }
 
@@ -335,7 +325,7 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
         b ^= read_u64(data, data.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);
@@ -343,6 +333,6 @@ const fn rapidhash_nano_core<const PROTECTED: bool>(mut a: u64, mut b: u64, mut 
 }
 
 #[inline(always)]
-pub(super) const fn rapidhash_finish<const PROTECTED: bool>(a: u64, b: u64, remainder: u64) -> u64 {
-    rapid_mix::<PROTECTED>(a ^ RAPID_SECRET[7], b ^ RAPID_SECRET[1] ^ remainder)
+pub(super) const fn rapidhash_finish<const PROTECTED: bool>(a: u64, b: u64, remainder: u64, secrets: &RapidSecrets) -> u64 {
+    rapid_mix::<PROTECTED>(a ^ 0xaaaaaaaaaaaaaaaa, b ^ secrets.secrets[1] ^ remainder)
 }

--- a/rapidhash/src/v3/rapid_file.rs
+++ b/rapidhash/src/v3/rapid_file.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use crate::util::chunked_stream_reader::ChunkedStreamReader;
 use crate::util::mix::{rapid_mix, rapid_mum};
 use crate::util::read::{read_u32, read_u64};
-use crate::v3::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidhash_seed};
+use super::{DEFAULT_RAPID_SECRETS, RapidSecrets, rapidhash_finish};
 
 /// Rapidhash a file, matching the C++ implementation.
 ///
@@ -10,7 +10,7 @@ use crate::v3::rapid_const::{RAPID_SEED, RAPID_SECRET, rapidhash_finish, rapidha
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
 pub fn rapidhash_v3_file<R: Read>(data: R) -> std::io::Result<u64> {
-    rapidhash_v3_file_inline::<R, false>(data, RAPID_SEED)
+    rapidhash_v3_file_inline::<R, false>(data, &DEFAULT_RAPID_SECRETS)
 }
 
 /// Rapidhash a file, matching the C++ implementation, with a custom seed.
@@ -18,8 +18,8 @@ pub fn rapidhash_v3_file<R: Read>(data: R) -> std::io::Result<u64> {
 /// This method will check the metadata for a file length, and then stream the file with a
 /// [BufReader] to compute the hash. This avoids loading the entire file into memory.
 #[inline]
-pub fn rapidhash_v3_file_seeded<R: Read>(data: R, seed: u64) -> std::io::Result<u64> {
-    rapidhash_v3_file_inline::<R, false>(data, seed)
+pub fn rapidhash_v3_file_seeded<R: Read>(data: R, secrets: &RapidSecrets) -> std::io::Result<u64> {
+    rapidhash_v3_file_inline::<R, false>(data, secrets)
 }
 
 /// Rapidhash a file, matching the C++ implementation.
@@ -35,15 +35,17 @@ pub fn rapidhash_v3_file_seeded<R: Read>(data: R, seed: u64) -> std::io::Result<
 /// Is marked with `#[inline(always)]` to force the compiler to inline and optimise the method.
 /// Can provide large performance uplifts for inputs where the length is known at compile time.
 #[inline(always)]
-pub fn rapidhash_v3_file_inline<R: Read, const PROTECTED: bool>(data: R, mut seed: u64) -> std::io::Result<u64> {
-    seed = rapidhash_seed(seed);
+pub fn rapidhash_v3_file_inline<R: Read, const PROTECTED: bool>(data: R, secrets: &RapidSecrets) -> std::io::Result<u64> {
     let mut reader = ChunkedStreamReader::new(data, 16);
-    let (a, b, _, remainder) = rapidhash_file_core::<R, PROTECTED>(0, 0, seed, &mut reader)?;
-    Ok(rapidhash_finish::<PROTECTED>(a, b, remainder))
+    let (a, b, _, remainder) = rapidhash_file_core::<R, PROTECTED>(0, 0, secrets, &mut reader)?;
+    Ok(rapidhash_finish::<PROTECTED>(a, b, remainder, secrets))
 }
 
 #[inline(always)]
-fn rapidhash_file_core<R: Read, const PROTECTED: bool>(mut a: u64, mut b: u64, mut seed: u64, iter: &mut ChunkedStreamReader<R>) -> std::io::Result<(u64, u64, u64, u64)> {
+fn rapidhash_file_core<R: Read, const PROTECTED: bool>(mut a: u64, mut b: u64, rapid_secrets: &RapidSecrets, iter: &mut ChunkedStreamReader<R>) -> std::io::Result<(u64, u64, u64, u64)> {
+    let mut seed = rapid_secrets.seed;
+    let secrets = &rapid_secrets.secrets;
+
     let mut chunk = iter.read_chunk(225)?;
     let remainder;
 
@@ -75,34 +77,34 @@ fn rapidhash_file_core<R: Read, const PROTECTED: bool>(mut a: u64, mut b: u64, m
         let mut see6 = seed;
 
         while chunk.len() > 224 {
-            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ RAPID_SECRET[0], read_u64(chunk, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ RAPID_SECRET[1], read_u64(chunk, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ RAPID_SECRET[2], read_u64(chunk, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ RAPID_SECRET[3], read_u64(chunk, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ RAPID_SECRET[4], read_u64(chunk, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ RAPID_SECRET[5], read_u64(chunk, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 96) ^ RAPID_SECRET[6], read_u64(chunk, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ secrets[0], read_u64(chunk, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ secrets[1], read_u64(chunk, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ secrets[2], read_u64(chunk, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ secrets[3], read_u64(chunk, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ secrets[4], read_u64(chunk, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ secrets[5], read_u64(chunk, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 96) ^ secrets[6], read_u64(chunk, 104) ^ see6);
 
-            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 112) ^ RAPID_SECRET[0], read_u64(chunk, 120) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 128) ^ RAPID_SECRET[1], read_u64(chunk, 136) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 144) ^ RAPID_SECRET[2], read_u64(chunk, 152) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 160) ^ RAPID_SECRET[3], read_u64(chunk, 168) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 176) ^ RAPID_SECRET[4], read_u64(chunk, 184) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 192) ^ RAPID_SECRET[5], read_u64(chunk, 200) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 208) ^ RAPID_SECRET[6], read_u64(chunk, 216) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 112) ^ secrets[0], read_u64(chunk, 120) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 128) ^ secrets[1], read_u64(chunk, 136) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 144) ^ secrets[2], read_u64(chunk, 152) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 160) ^ secrets[3], read_u64(chunk, 168) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 176) ^ secrets[4], read_u64(chunk, 184) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 192) ^ secrets[5], read_u64(chunk, 200) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 208) ^ secrets[6], read_u64(chunk, 216) ^ see6);
 
             iter.consume(224);
             chunk = iter.read_chunk(225)?;  // must read 1 more byte for > 224
         }
 
         if chunk.len() > 112 {
-            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ RAPID_SECRET[0], read_u64(chunk, 8) ^ seed);
-            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ RAPID_SECRET[1], read_u64(chunk, 24) ^ see1);
-            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ RAPID_SECRET[2], read_u64(chunk, 40) ^ see2);
-            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ RAPID_SECRET[3], read_u64(chunk, 56) ^ see3);
-            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ RAPID_SECRET[4], read_u64(chunk, 72) ^ see4);
-            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ RAPID_SECRET[5], read_u64(chunk, 88) ^ see5);
-            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 96) ^ RAPID_SECRET[6], read_u64(chunk, 104) ^ see6);
+            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ secrets[0], read_u64(chunk, 8) ^ seed);
+            see1 = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ secrets[1], read_u64(chunk, 24) ^ see1);
+            see2 = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ secrets[2], read_u64(chunk, 40) ^ see2);
+            see3 = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ secrets[3], read_u64(chunk, 56) ^ see3);
+            see4 = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ secrets[4], read_u64(chunk, 72) ^ see4);
+            see5 = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ secrets[5], read_u64(chunk, 88) ^ see5);
+            see6 = rapid_mix::<PROTECTED>(read_u64(chunk, 96) ^ secrets[6], read_u64(chunk, 104) ^ see6);
 
             chunk = &chunk[112..chunk.len()];
         }
@@ -115,17 +117,17 @@ fn rapidhash_file_core<R: Read, const PROTECTED: bool>(mut a: u64, mut b: u64, m
         seed ^= see2;
 
         if chunk.len() > 16 {
-            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ RAPID_SECRET[2], read_u64(chunk, 8) ^ seed);
+            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 0) ^ secrets[2], read_u64(chunk, 8) ^ seed);
             if chunk.len() > 32 {
-                seed = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ RAPID_SECRET[2], read_u64(chunk, 24) ^ seed);
+                seed = rapid_mix::<PROTECTED>(read_u64(chunk, 16) ^ secrets[2], read_u64(chunk, 24) ^ seed);
                 if chunk.len() > 48 {
-                    seed = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ RAPID_SECRET[1], read_u64(chunk, 40) ^ seed);
+                    seed = rapid_mix::<PROTECTED>(read_u64(chunk, 32) ^ secrets[1], read_u64(chunk, 40) ^ seed);
                     if chunk.len() > 64 {
-                        seed = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ RAPID_SECRET[1], read_u64(chunk, 56) ^ seed);
+                        seed = rapid_mix::<PROTECTED>(read_u64(chunk, 48) ^ secrets[1], read_u64(chunk, 56) ^ seed);
                         if chunk.len() > 80 {
-                            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ RAPID_SECRET[2], read_u64(chunk, 72) ^ seed);
+                            seed = rapid_mix::<PROTECTED>(read_u64(chunk, 64) ^ secrets[2], read_u64(chunk, 72) ^ seed);
                             if chunk.len() > 96 {
-                                seed = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ RAPID_SECRET[1], read_u64(chunk, 88) ^ seed);
+                                seed = rapid_mix::<PROTECTED>(read_u64(chunk, 80) ^ secrets[1], read_u64(chunk, 88) ^ seed);
                             }
                         }
                     }
@@ -139,7 +141,7 @@ fn rapidhash_file_core<R: Read, const PROTECTED: bool>(mut a: u64, mut b: u64, m
         b ^= read_u64(last, last.len() - 8);
     }
 
-    a ^= RAPID_SECRET[1];
+    a ^= secrets[1];
     b ^= seed;
 
     (a, b) = rapid_mum::<PROTECTED>(a, b);

--- a/rapidhash/src/v3/seed.rs
+++ b/rapidhash/src/v3/seed.rs
@@ -1,0 +1,148 @@
+//! Reliable seeding and secrets generation for the hash functions.
+
+use crate::util::mix::rapid_mix;
+
+/// The default seed used in the C++ implementation.
+pub(crate) const DEFAULT_SEED: u64 = 0;
+
+/// Used only for generating random secrets.
+const DEFAULT_SECRETS: [u64; 7] = [
+    0x2d358dccaa6c78a5,
+    0x8bb84b93962eacc9,
+    0x4b33a62ed433d4a3,
+    0x4d5a2da51de1aa47,
+    0xa0761d6478bd642f,
+    0xe7037ed1a0b428db,
+    0x90ed1765281c388c,
+];
+
+/// The default rapidhash secrets used in the C++ implementation.
+///
+/// We recommend generating your own secrets using the [`RapidSecrets::seed`] method to avoid
+/// trivial collision attacks if you need minimal HashDoS protection.
+pub const DEFAULT_RAPID_SECRETS: RapidSecrets = RapidSecrets::seed_cpp(DEFAULT_SEED);
+
+/// Hold the seed and secrets to be used by rapidhash.
+///
+/// RapidSecrets premix the seed and generate a set of other secrets based on the seed that are all
+/// used in the hashing process. There are some quality checks on the random values to ensure a
+/// reasonable distribution of entropy in the generated secrets.
+///
+/// Constructing this struct is fairly cheap, but unnecessary in the critical path. We therefore
+/// recommend instantiating it once and re-using the same instance for any persistent hashing. The
+/// `seed` method is marked `const` to also do so at compile time.
+///
+/// # Minimal HashDoS Protection
+/// We recommend changing the default seed and secrets must be changed to avoid trivial collision
+/// attacks. For persistent hashing, you can hard code your own randomised seed at compile time.
+///
+/// ```rust
+/// use rapidhash::v3::RapidSecrets;
+/// const DEFAULT_SECRETS: RapidSecrets = RapidSecrets::seed(0x123456);  // <-- change this value!
+///
+/// /// Export your chosen rapidhash version and secrets for use throughout your project.
+/// pub fn rapidhash(data: &[u8]) -> u64 {
+///     rapidhash::v3::rapidhash_v3_seeded(data, &DEFAULT_SECRETS)
+/// }
+/// ```
+///
+/// TODO: serde or serialization support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RapidSecrets {
+    /// The core rapidhash seed.
+    pub seed: u64,
+
+    /// The secrets, effectively other seeds used in the hashing process.
+    pub secrets: [u64; 7],
+}
+
+impl RapidSecrets {
+    /// Generate secrets from a given randomised seed.
+    ///
+    /// Note the chosen seed will be pre-mixed to further randomise it, and the secrets will be
+    /// computed based on the seed.
+    ///
+    /// If compatibility with the C++ implementation is required, use the `seed_cpp` method instead.
+    #[inline]
+    pub const fn seed(seed: u64) -> Self {
+        let seed = premix_seed(seed, 0);
+        let mut secrets = [0; 7];
+        secrets[0] = premix_seed(seed, 0);
+        secrets[1] = premix_seed(secrets[0], 1);
+        secrets[2] = premix_seed(secrets[1], 2);
+        secrets[3] = premix_seed(secrets[2], 3);
+        secrets[4] = premix_seed(secrets[3], 4);
+        secrets[5] = premix_seed(secrets[4], 5);
+        secrets[6] = premix_seed(secrets[5], 6);
+        Self { seed, secrets }
+    }
+
+    /// Creates a new `RapidSecrets` instance with a different seed and the same secrets.
+    ///
+    /// This is useful for in-memory hashing, so we can quickly use a different seed for other
+    /// HashMaps.
+    #[inline]
+    pub const fn reseed(&self) -> Self {
+        Self {
+            seed: premix_seed(self.seed, 6),
+            secrets: self.secrets,
+        }
+    }
+
+    /// Creates a new `RapidSecrets` instance using a seed and secrets that are compatible with the
+    /// C++ implementation.
+    ///
+    /// Note that these **use the default secrets** and therefore are liable to some trivial
+    /// collision attacks, as randomising both the seed and secrets is necessary to provide minimal
+    /// HashDoS resistance.
+    #[inline]
+    pub const fn seed_cpp(seed: u64) -> Self {
+        Self {
+            seed: rapidhash_seed(seed),
+            secrets: DEFAULT_SECRETS,
+        }
+    }
+
+    /// Creates a new `RapidSecrets` instance with a randomised seed and secrets.
+    ///
+    /// The quality of the randomness will be better with the `rand` feature enabled.
+    #[inline]
+    pub fn random() -> Self {
+        let seed = crate::inner::seeding::seed::get_seed();
+        let secrets = crate::inner::seeding::secrets::get_secrets();
+
+        Self {
+            seed,
+            secrets: *secrets,
+        }
+    }
+}
+
+#[inline(always)]
+const fn rapidhash_seed(seed: u64) -> u64 {
+    seed ^ rapid_mix::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[1])
+}
+
+#[inline]
+const fn premix_seed(mut seed: u64, i: usize) -> u64 {
+    seed ^= rapid_mix::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[i]);
+
+    // ensure the seeds are of reasonable non-zero quality
+    const HI: u64 = 0xFFFF << 48;
+    const MI: u64 = 0xFFFF << 24;
+    const LO: u64 = 0xFFFF;
+
+    if (seed & HI) == 0 {
+        seed |= 1u64 << 63;
+    }
+
+    if (seed & MI) == 0 {
+        seed |= 1u64 << 31;
+    }
+
+    if (seed & LO) == 0 {
+        seed |= 1u64;
+    }
+
+    seed
+}

--- a/rapidhash/tests/cli.rs
+++ b/rapidhash/tests/cli.rs
@@ -56,9 +56,9 @@ fn cli_versions() {
 
     let versions = [
         ("--v1", rapidhash_v1(input).to_string()),
-        ("--v2.0", rapidhash_v2_inline::<0, false, false>(input, 0).to_string()),
-        ("--v2.1", rapidhash_v2_inline::<1, false, false>(input, 0).to_string()),
-        ("--v2.2", rapidhash_v2_inline::<2, false, false>(input, 0).to_string()),
+        ("--v2.0", rapidhash_v2_inline::<0, false, false>(input, &rapidhash::v2::DEFAULT_RAPID_SECRETS).to_string()),
+        ("--v2.1", rapidhash_v2_inline::<1, false, false>(input, &rapidhash::v2::DEFAULT_RAPID_SECRETS).to_string()),
+        ("--v2.2", rapidhash_v2_inline::<2, false, false>(input, &rapidhash::v2::DEFAULT_RAPID_SECRETS).to_string()),
         ("--v3", rapidhash_v3(input).to_string()),
     ];
 


### PR DESCRIPTION
Allow portable hashers to change the default secrets for better HashDoS resistance, while still retaining C++ compatibility.