### PR TITLE
Fix compiling on targets without atomic pointers

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -106,3 +106,17 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
       - name: Compile and run tests
         run: cargo build -p rapidhash --target wasm32-unknown-unknown
+
+  test-no-atomics:
+    # check that the no-atomics target compiles, but it sadly can't run tests
+    name: "Build (no atomics)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust dependency cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install no-atomics target
+        run: rustup target add thumbv6m-none-eabi
+      - name: Compile and run tests
+        run: cargo build -p rapidhash --no-default-features --lib --target thumbv6m-none-eabi

--- a/rapidhash/src/inner/state.rs
+++ b/rapidhash/src/inner/state.rs
@@ -8,6 +8,17 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// This is designed to provide some HashDoS resistance by using a random seed per hashmap, and
 /// a global random set of secrets.
 ///
+/// # Portability
+///
+/// On most target platforms, the secrets are randomly initialized once and cached globally for the
+/// lifetime of the program using a mix of ASLR and other entropy sources. The seed is randomly
+/// initialized for each new instance of `RandomState` using only ASLR and a mixing step.
+///
+/// On targets without atomic pointer support, the global secrets will not be randomised, and
+/// instead will fall back to the default secrets. This means these platforms will not have minimal
+/// HashDoS resistance guarantees. If this is important for your application, please raise a GitHub
+/// issue to improve support for these platforms.
+///
 /// # Example
 /// ```rust
 /// use std::collections::HashMap;

--- a/rapidhash/src/inner/state.rs
+++ b/rapidhash/src/inner/state.rs
@@ -29,12 +29,17 @@ pub struct RandomState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT:
 impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> RandomState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
     /// Create a new random state with a random seed.
     ///
-    /// With the `rand` feature enabled, this will use [rand::random] to initialise the seed.
+    /// The seed is always randomised by using ASLR on every new instance of RandomState.
     ///
-    /// Without `rand` but with the `std` feature enabled, this will use [crate::rapidrng_time] to
-    /// initialise the seed.
+    /// With the `rand` feature enabled, the secrets will be randomised using [rand::random].
+    /// Otherwise, a mix of ASLR and some other poorer sources of entropy will be mixed together to
+    /// generate the secrets. The secrets are statically cached for the lifetime of the program
+    /// after their initial generation.
+    ///
+    /// On platforms that do not support atomic pointers, the secrets will be the default rapidhash
+    /// secrets, which are not randomised. Therefore, **targets without atomic pointer support will
+    /// not have minimal HashDoS resistance guarantees**.
     #[inline]
-    #[cfg(target_has_atomic = "ptr")]
     pub fn new() -> Self {
         Self {
             seed: super::seeding::seed::get_seed(),


### PR DESCRIPTION
Fixes #38.

Adds CI compilation check for `thumbv6m-none-eabi` to prevent regeressions.