### PR TITLE
Granular benchmarking for inputs up to 256 bytes

### DIFF
--- a/rapidhash-bench/Cargo.toml
+++ b/rapidhash-bench/Cargo.toml
@@ -50,6 +50,7 @@ farmhash = "1.1.5"
 highway = "1.2.0"
 rustc-hash = "2.0.0"
 foldhash = "0.1.5"
+museair = "0.4.0"
 
 # benchmarking helpers
 criterion = { version = "0.7.0", default-features = false, features = ["rayon", "cargo_bench_support"] }


### PR DESCRIPTION
Generates helpful charts for byte-by-byte input sizes such as the following chart (run against foldhash's latest master).

![bench_hash](https://github.com/user-attachments/assets/19f1d723-1523-4953-b9f5-586aa86da9ff)
