### PR TITLE
Faster RNG for benchmarking

### DIFF
--- a/rapidhash-bench/benches/bench/basic.rs
+++ b/rapidhash-bench/benches/bench/basic.rs
@@ -12,6 +12,7 @@ fn profile_bytes<H: BuildHasher + Default>(
     prefix: &str,
     group: &mut BenchmarkGroup<'_, WallTime>,
 ) {
+    let mut rng = rand::rng();  // rapidhash::rng::RapidRng::default();
     let name = format!("{prefix}_{bytes_len}");
     let build_hasher = H::default();
 
@@ -31,7 +32,7 @@ fn profile_bytes<H: BuildHasher + Default>(
     group.bench_function(&name, |b| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; bytes_len];
-            rand::rng().fill(slice.as_mut_slice());
+            rng.fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             // hash_one seems to cause significant overhead for some hashers, likely related to
@@ -52,6 +53,7 @@ fn profile_int<H: BuildHasher + Default, I: Hash>(
 where
     StandardUniform: Distribution<I>,
 {
+    let mut rng = rapidhash::rng::RapidRng::default();
     let name = format!("{int_name}");
     let build_hasher = H::default();
 
@@ -59,7 +61,7 @@ where
     group.throughput(Throughput::Elements(1));
     group.bench_function(&name, |b| {
         b.iter_batched(
-            || rand::random::<I>(),
+            || rng.random::<I>(),
             |value| {
                 black_box(build_hasher.hash_one(black_box(value)))
             },
@@ -107,6 +109,7 @@ fn profile_bytes_raw<H: Fn(&[u8], u64) -> u64>(
     prefix: &str,
     group: &mut BenchmarkGroup<'_, WallTime>,
 ) {
+    let mut rng = rapidhash::rng::RapidRng::default();
     let name = format!("{prefix}_{bytes_len}");
     group.warm_up_time(std::time::Duration::from_millis(250));
     group.measurement_time(std::time::Duration::from_millis(2000));
@@ -127,7 +130,7 @@ fn profile_bytes_raw<H: Fn(&[u8], u64) -> u64>(
     group.bench_function(&name, |b| {
         b.iter_batched_ref(|| {
             let mut slice = vec![0u8; bytes_len];
-            rand::rng().fill(slice.as_mut_slice());
+            rng.fill(slice.as_mut_slice());
             slice
         }, |bytes| {
             black_box(hash(black_box(bytes), 0xbdd89aa982704029))  // using rapidhash V1 seed

--- a/rapidhash-bench/benches/bench/compiled.rs
+++ b/rapidhash-bench/benches/bench/compiled.rs
@@ -2,6 +2,7 @@ use const_random::const_random;
 use criterion::{Bencher, Criterion};
 use rand::prelude::*;
 use rapidhash::RapidHashMap;
+use rapidhash::rng::RapidRng;
 use rapidhash::v3::rapidhash_v3;
 
 /// Benchmark approaches for matching bytes against compile-time known values.
@@ -113,21 +114,22 @@ const HASHES: [u64; INPUT_COUNT] = {
 };
 
 const MISMATCH_PCT: u8 = 20;
-fn random_input() -> [u8; INPUT_LEN] {
+fn random_input(rng: &mut impl Rng) -> [u8; INPUT_LEN] {
     let mismatch_branch = rand::rng().random_range(0..100);
     if mismatch_branch < MISMATCH_PCT {
         let mut buffer = [0u8; INPUT_LEN];
-        rand::rng().fill(&mut buffer);
+        rng.fill(&mut buffer);
         buffer
     } else {
-        *INPUTS.choose(&mut rand::rng()).unwrap()
+        *INPUTS.choose(rng).unwrap()
     }
 }
 
 pub fn bench_match_hash() -> Box<dyn FnMut(&mut Bencher)> {
+    let mut rng = RapidRng::default();
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
-            random_input().to_vec()
+            random_input(&mut rng).to_vec()
         }, |i: &mut Vec<u8>| {
             let hash = rapidhash_v3(i.as_slice());
             match hash {
@@ -179,9 +181,10 @@ pub fn bench_match_hash() -> Box<dyn FnMut(&mut Bencher)> {
 }
 
 pub fn bench_match_slice() -> Box<dyn FnMut(&mut Bencher)> {
+    let mut rng = RapidRng::default();
     Box::new(move |b: &mut Bencher| {
         b.iter_batched_ref(|| {
-            random_input().to_vec()
+            random_input(&mut rng).to_vec()
         }, |i: &mut Vec<u8>| {
             match i.as_slice() {
                 h if h == &INPUTS[0] => const_random!(u64),
@@ -233,6 +236,7 @@ pub fn bench_match_slice() -> Box<dyn FnMut(&mut Bencher)> {
 
 /// This is equivalent to using lazy_static to initialize a hashmap at runtime.
 pub fn bench_hashmap_get() -> Box<dyn FnMut(&mut Bencher)> {
+    let mut rng = RapidRng::default();
     Box::new(move |b: &mut Bencher| {
         let hashmap: RapidHashMap<Vec<u8>, u64> = INPUTS
             .into_iter()
@@ -241,7 +245,7 @@ pub fn bench_hashmap_get() -> Box<dyn FnMut(&mut Bencher)> {
             .collect();
 
         b.iter_batched_ref(|| {
-            random_input().to_vec()
+            random_input(&mut rng).to_vec()
         }, |i: &mut Vec<u8>| {
             *hashmap.get(i.as_slice()).unwrap_or(&const_random!(u64))
         }, criterion::BatchSize::SmallInput);

--- a/rapidhash-bench/benches/bench/emails.rs
+++ b/rapidhash-bench/benches/bench/emails.rs
@@ -4,6 +4,7 @@ use rand::distr::{Alphanumeric, SampleString};
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::Distribution;
 use wyhash::WyHash;
+use rapidhash::rng::RapidRng;
 
 pub fn bench(c: &mut Criterion) {
     let groups: &[(
@@ -34,7 +35,7 @@ pub fn bench(c: &mut Criterion) {
 }
 
 fn sample_emails(count: usize) -> Vec<String> {
-    let mut rng = rand::rng();
+    let mut rng = RapidRng::default();
 
     // weights roughly estimated from https://atdata.com/blog/long-email-addresses/
     let weights = [

--- a/rapidhash-bench/benches/realworld/main.rs
+++ b/rapidhash-bench/benches/realworld/main.rs
@@ -14,6 +14,7 @@ const NUM_PRECOMPUTED_KEYS: usize = 1024;
 mod distribution;
 
 use distribution::Distribution;
+use rapidhash::rng::RapidRng;
 
 fn profile_hashonly<S: BuildHasher + Default, D: Distribution>(
     hash_name: &str,
@@ -21,7 +22,7 @@ fn profile_hashonly<S: BuildHasher + Default, D: Distribution>(
     c: &mut BenchmarkGroup<'_, WallTime>,
 ) {
     let name = format!("hashonly-{}-{hash_name}", distr.name().to_lowercase());
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = RapidRng::seed_from_u64(RNG_SEED);
 
     let hasher = S::default();
 
@@ -48,7 +49,7 @@ fn profile_lookup_hit<S: BuildHasher + Default, D: Distribution>(
     c: &mut BenchmarkGroup<'_, WallTime>,
 ) {
     let name = format!("lookuphit-{}-{hash_name}", distr.name().to_lowercase());
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = RapidRng::seed_from_u64(RNG_SEED);
 
     c.bench_function(&name, |b| {
         b.iter_custom(|iters| {
@@ -84,7 +85,7 @@ fn profile_lookup_miss<S: BuildHasher + Default, D: Distribution>(
     c: &mut BenchmarkGroup<'_, WallTime>,
 ) {
     let name = format!("lookupmiss-{}-{hash_name}", distr.name().to_lowercase());
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = RapidRng::seed_from_u64(RNG_SEED);
 
     c.bench_function(&name, |b| {
         b.iter_custom(|iters| {
@@ -119,7 +120,7 @@ fn profile_set_build<S: BuildHasher + Default, D: Distribution>(
     c: &mut BenchmarkGroup<'_, WallTime>,
 ) {
     let name = format!("setbuild-{}-{hash_name}", distr.name().to_lowercase());
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = RapidRng::seed_from_u64(RNG_SEED);
 
     c.bench_function(&name, |b| {
         b.iter_custom(|iters| {


### PR DESCRIPTION
This changes the rng for generating benchmark fixtures from `rand::rng()` to `rapidhash::rng::RapidRng`. This seems to affect the actual benchmark results somehow, which needs investigating, as fixture generation should be entirely outside of the benchmark timing. It could be the AWS m7i host has a noisy neighbour or throttling.