### PR TITLE
Replace `doc_auto_cfg` and `doc_cfg_hide` with `doc_cfg`

### DIFF
--- a/rapidhash/src/lib.rs
+++ b/rapidhash/src/lib.rs
@@ -1,9 +1,8 @@
 #![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 #![cfg_attr(not(docsrs), doc = "# Rapidhash")]
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg_hide))]
-#![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, doc(auto_cfg(hide(docsrs))))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(likely_unlikely))]


### PR DESCRIPTION
The `doc_auto_cfg` and `doc_cfg_hide` features were [recently removed](https://github.com/rust-lang/rust/pull/138907). This commit replaces them with the new `doc_cfg` feature which should work as an drop-in replacement.

I noticed this because building the docs for one of my crates failed due to `doc_auto_cfg` in this crate and `rand_core`. The PR https://github.com/rust-random/rand/pull/1664 contains the fix for the `rand_core` and `rand` crates.