### PR TITLE
Implement FixedState to complement GlobalState

### DIFF
--- a/rapidhash/src/fast.rs
+++ b/rapidhash/src/fast.rs
@@ -1,8 +1,8 @@
 //! In-memory hashing: RapidHasher with a focus on speed.
 //!
-//! Designed to maximise hashmap fetch and insert performance on most datasets.
+//! Designed to maximize hashmap fetch and insert performance on most datasets.
 //!
-//! This is a specific instantiation of the [crate::inner] module with the following settings:
+//! This is a specific instantiation of the [`crate::inner`] module with the following settings:
 //! - `AVALANCHE` is disabled.
 //! - `SPONGE` is enabled.
 //! - `COMPACT` is disabled, unless building for WASM targets.
@@ -15,50 +15,71 @@ const PROTECTED: bool = false;
 
 use crate::inner;
 
-/// A [std::hash::Hasher] inspired by [crate::v3::rapidhash_v3] with a focus on speed and throughput.
+/// A [`std::hash::Hasher`] inspired by [`crate::v3::rapidhash_v3`] with a focus on speed and throughput.
 ///
-/// This is an alias for [inner::RapidHasher] with the following settings:
+/// This is an alias for [`inner::RapidHasher`] with the following settings:
 /// - `AVALANCHE` is disabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::quality::RapidHasher] for a higher quality hash output where necessary.
+/// Use [`crate::quality::RapidHasher`] for a higher quality hash output where necessary.
 pub type RapidHasher<'s> = inner::RapidHasher<'s, AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A rapidhash equivalent to [std::hash::RandomState] that uses a random seed and secrets for
+/// A rapidhash equivalent to [`std::hash::RandomState`] that uses a random seed and secrets for
 /// minimal DoS resistance.
 ///
-/// This initialises a [crate::quality::RapidHasher] with the following settings:
+/// Each instance of [`crate::quality::RandomState`] will use different random seed and secrets. See [`crate::quality::GlobalState`] for
+/// a version that randomizes only once on startup.
+///
+/// This initialises a [`crate::quality::RapidHasher`] with the following settings:
 /// - `AVALANCHE` is disabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::quality::RandomState] for a higher quality but slower hash output where desirable.
+/// Use [`crate::quality::RandomState`] for a higher quality but slower hash output where desirable.
 pub type RandomState = inner::RandomState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A [std::hash::BuildHasher] trait compatible hasher that uses the [RapidHasher] algorithm.
+/// A [`std::hash::BuildHasher`] that uses user-provided secrets and seed.
 ///
-/// This initialises a [crate::quality::RapidHasher] with the following settings:
+/// This initialises a [`crate::quality::RapidHasher`] with the following settings:
 /// - `AVALANCHE` is disabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::quality::SeedableState] for a higher quality but slower hash output where desirable.
+/// Use [`crate::quality::SeedableState`] for a higher quality but slower hash output where desirable.
 pub type SeedableState<'secrets> = inner::SeedableState<'secrets, AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A [std::hash::BuildHasher] trait compatible hasher that uses the [RapidHasher] algorithm.
+/// A [`std::hash::BuildHasher`] that uses a global seed and secrets, randomized only once on startup.
 ///
-/// This initialises a [crate::quality::RapidHasher] with the following settings:
+/// All instances of GlobalState will use the same global seed and secrets for the lifetime of the
+/// program. This provides minimal HashDoS resistance by randomising the seed and secrets between
+/// application runs.
+///
+/// This initialises a [`RapidHasher`] with the following settings:
 /// - `AVALANCHE` is disabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::quality::GlobalState] for a higher quality but slower hash output where desirable.
+/// Use [`crate::quality::GlobalState`] for a higher quality but slower hash output where desirable.
 pub type GlobalState = inner::GlobalState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;
+
+/// A [`std::hash::BuildHasher`] using the fixed default seed and secrets.
+///
+/// This is **NOT** HashDoS resistant, as it does not randomize the seed or secrets. Please see
+/// [`crate::quality::GlobalState`] for HashDoS resistance.
+///
+/// This initialises a [`crate::quality::RapidHasher`] with the following settings:
+/// - `AVALANCHE` is disabled.
+/// - `SPONGE` is enabled.
+/// - `COMPACT` is disabled.
+/// - `PROTECTED` is disabled.
+///
+/// Use [`crate::quality::FixedState`] for a higher quality but slower hash output where desirable.
+pub type FixedState = inner::FixedState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
 #[cfg(any(feature = "std", docsrs))]
 #[deprecated(since = "0.4.0", note = "Please use the top-level rapidhash::RapidHashMap instead")]

--- a/rapidhash/src/inner/state/fixed_state.rs
+++ b/rapidhash/src/inner/state/fixed_state.rs
@@ -1,0 +1,78 @@
+use core::hash::BuildHasher;
+use crate::inner::RapidHasher;
+
+/// A `std::hash::BuildHasher` trait compatible hasher that uses the [`RapidHasher`] algorithm
+/// with the default fixed seed and secrets.
+///
+/// This is not recommended unless you need determinism between program runs, but please note that
+/// stable hash outputs are not guaranteed between either rapidhash versions, compiler versions, or
+/// different platforms.
+///
+/// # Not HashDoS Resistant
+/// These secrets are **NOT HashDoS resistant**, as they use the default rapidhash secrets. Instead,
+/// consider using [`crate::inner::GlobalState`] for HashDoS resistant hashing with secrets that are
+/// static for the lifetime of the program.
+///
+/// # Portable Hashing
+/// FixedState is not suitable for portable hashing. Please use [`crate::v3::rapidhash_v3`] and
+/// similar methods instead.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct FixedState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> {}
+
+impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> FixedState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
+    /// Create a new fixed state with a fixed seed and secrets.
+    ///
+    /// # Not HashDoS Resistant
+    /// These secrets are **NOT HashDoS resistant**, as they use the default rapidhash secrets. Instead,
+    /// consider using [`crate::inner::GlobalState`] for HashDoS resistant hashing with secrets that
+    /// are static for the lifetime of the program.
+    ///
+    /// # Portable Hashing
+    /// FixedState is not suitable for portable hashing. Please use [`crate::v3::rapidhash_v3`] and
+    /// similar methods instead.
+    #[inline]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> Default for FixedState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool>  BuildHasher for FixedState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
+    type Hasher = RapidHasher<'static, AVALANCHE, SPONGE, COMPACT, PROTECTED>;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        RapidHasher::new_precomputed_seed(
+            crate::inner::seed::rapidhash_seed(0),
+            &crate::inner::seed::DEFAULT_SECRETS,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::hash::BuildHasher;
+
+    type FixedState = super::FixedState<false, true, false, false>;
+
+    #[test]
+    fn test_global_state() {
+        assert_eq!(core::mem::size_of::<FixedState>(), 0);
+
+        let state1 = FixedState::new();
+        let state2 = FixedState::new();
+
+        let finish1a = state1.hash_one(b"hello");
+        let finish1b = state1.hash_one(b"hello");
+        let finish2a = state2.hash_one(b"hello");
+
+        assert_eq!(finish1a, finish1b);
+        assert_eq!(finish1a, finish2a);
+    }
+}

--- a/rapidhash/src/inner/state/global_state.rs
+++ b/rapidhash/src/inner/state/global_state.rs
@@ -2,7 +2,7 @@ use core::hash::BuildHasher;
 use crate::inner::RapidHasher;
 use crate::inner::seeding::secrets::GlobalSecrets;
 
-/// A `std::hash::BuildHasher` trait compatible hasher that uses the [RapidHasher] algorithm
+/// A `std::hash::BuildHasher` trait compatible hasher that uses the [`RapidHasher`] algorithm
 /// with a global seed and secrets.
 ///
 /// The global secrets are randomized on the first instantiation, and then every subsequent instance
@@ -10,18 +10,18 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// duration of the program.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct GlobalState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> {
-    /// The global secrets is a zero-sized type to keep HashMap<K, V, RandomState> small.
+    /// The global secrets is a zero-sized type to keep `HashMap<K, V, RandomState>` small.
     secrets: GlobalSecrets,
 }
 
 impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> GlobalState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
     /// Create a new global state with a global seed and secrets.
     ///
-    /// The seed and secrets will be randomised on the first instantiation of `GlobalState`, but all
+    /// The seed and secrets will be randomized on the first instantiation of `GlobalState`, but all
     /// subsequent instances will share the same seed and secrets.
     ///
     /// On platforms that do not support atomic pointers, the secrets will be the default rapidhash
-    /// secrets, which are not randomised. Therefore, **targets without atomic pointer support will
+    /// secrets, which are not randomized. Therefore, **targets without atomic pointer support will
     /// not have minimal HashDoS resistance guarantees**.
     #[inline]
     pub fn new() -> Self {
@@ -31,7 +31,7 @@ impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTE
     }
 }
 
-/// Warning that `GlobalState` only randomises the seed on platforms that support atomic pointers.
+/// Warning that `GlobalState` only randomizes the seed on platforms that support atomic pointers.
 impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> Default for GlobalState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
     #[inline]
     fn default() -> Self {

--- a/rapidhash/src/inner/state/mod.rs
+++ b/rapidhash/src/inner/state/mod.rs
@@ -1,7 +1,9 @@
 mod random_state;
 mod seedable_state;
 mod global_state;
+mod fixed_state;
 
+pub use fixed_state::FixedState;
 pub use global_state::GlobalState;
 pub use random_state::RandomState;
 pub use seedable_state::SeedableState;

--- a/rapidhash/src/quality.rs
+++ b/rapidhash/src/quality.rs
@@ -1,6 +1,6 @@
 //! In-memory hashing: RapidHasher with a focus on hash quality.
 //!
-//! This is a specific instantiation of the [crate::inner] module with the following settings:
+//! This is a specific instantiation of the [`crate::inner`] module with the following settings:
 //! - `AVALANCHE` is enabled.
 //! - `SPONGE` is enabled.
 //! - `COMPACT` is disabled, unless building for WASM targets.
@@ -13,47 +13,68 @@ const PROTECTED: bool = false;
 
 use crate::inner;
 
-/// A [std::hash::Hasher] inspired by [crate::v3::rapidhash_v3] with a focus on speed and throughput.
+/// A [`std::hash::Hasher`] inspired by [`crate::v3::rapidhash_v3`] with a focus on speed and throughput.
 ///
-/// This is an alias for [inner::RapidHasher] with the following settings:
+/// This is an alias for [`inner::RapidHasher`] with the following settings:
 /// - `AVALANCHE` is enabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::fast::RapidHasher] for a lower quality but faster hash output where desirable.
+/// Use [`crate::fast::RapidHasher`] for a lower quality but faster hash output where desirable.
 pub type RapidHasher<'s> = inner::RapidHasher<'s, AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A rapidhash equivalent to [std::hash::RandomState] that uses a random seed and secrets for
+/// A rapidhash equivalent to [`std::hash::RandomState`] that uses a random seed and secrets for
 /// minimal DoS resistance.
 ///
-/// This initialises a [RapidHasher] with the following settings:
+/// Each instance of [`RandomState`] will use different random seed and secrets. See [GlobalState] for
+/// a version that randomizes only once on startup.
+///
+/// This initialises a [`RapidHasher`] with the following settings:
 /// - `AVALANCHE` is enabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::fast::RandomState] for a lower quality but faster hash output where desirable.
+/// Use [`crate::fast::RandomState`] for a lower quality but faster hash output where desirable.
 pub type RandomState = inner::RandomState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A [std::hash::BuildHasher] trait compatible hasher that uses the [crate::fast::RapidHasher] algorithm.
+/// A [`std::hash::BuildHasher`] that uses user-provided secrets and seed.
 ///
-/// This initialises a [RapidHasher] with the following settings:
+/// This initialises a [`RapidHasher`] with the following settings:
 /// - `AVALANCHE` is enabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::fast::SeedableState] for a lower quality but faster hash output where desirable.
+/// Use [`crate::fast::SeedableState`] for a lower quality but faster hash output where desirable.
 pub type SeedableState<'secrets> = inner::SeedableState<'secrets, AVALANCHE, SPONGE, COMPACT, PROTECTED>;
 
-/// A [std::hash::BuildHasher] trait compatible hasher that uses the [crate::fast::RapidHasher] algorithm.
+/// A [`std::hash::BuildHasher`] that uses a global seed and secrets, randomized only once on startup.
 ///
-/// This initialises a [crate::quality::RapidHasher] with the following settings:
+/// All instances of GlobalState will use the same global seed and secrets for the lifetime of the
+/// program. This provides minimal HashDoS resistance by randomising the seed and secrets between
+/// application runs.
+///
+/// This initialises a [`RapidHasher`] with the following settings:
 /// - `AVALANCHE` is disabled.
 /// - `SPONGE` is enabled.
 /// - `COMPACT` is disabled.
 /// - `PROTECTED` is disabled.
 ///
-/// Use [crate::fast::GlobalState] for a lower quality but faster hash output where desirable.
+/// Use [`crate::fast::GlobalState`] for a lower quality but faster hash output where desirable.
 pub type GlobalState = inner::GlobalState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;
+
+/// A [`std::hash::BuildHasher`] using the fixed default seed and secrets.
+///
+/// This is **NOT** HashDoS resistant, as it does not randomize the seed or secrets. Please see
+/// [`GlobalState`] for HashDoS resistance.
+///
+/// This initialises a [`RapidHasher`] with the following settings:
+/// - `AVALANCHE` is disabled.
+/// - `SPONGE` is enabled.
+/// - `COMPACT` is disabled.
+/// - `PROTECTED` is disabled.
+///
+/// Use [`crate::fast::FixedState`] for a higher quality but slower hash output where desirable.
+pub type FixedState = inner::FixedState<AVALANCHE, SPONGE, COMPACT, PROTECTED>;


### PR DESCRIPTION
Beyond simplifying porting between hashing libraries, it's hard to see how this is useful to use correctly versus GlobalState, given portable hashing is not recommended with `RapidHasher`. This would simply encourage it...