### PR TITLE
Symlink license files for rapidhash crate.

### DIFF
--- a/rapidhash/LICENSE-APACHE
+++ b/rapidhash/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rapidhash/LICENSE-MIT
+++ b/rapidhash/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This will ensure that the full license text is published to crates.io for the next release of the crate.

I'm in the process of updating Fuchsia's import of this crate but we fetch our crates from crates.io and our lawyers require that all external dependencies we consume are distributed with the full text of the license and they seems to be [missing from the 4.2.1 release](https://docs.rs/crate/rapidhash/4.2.1/source/).

I checked manually that this got the files into the right place by running `cargo package` in the rapidhash subdir before and after this change and examining the contents of the tarball. Without this change they're missing, after this change they're present.