### PR TITLE
Derive Debug for RandomState

### DIFF
--- a/rapidhash/src/inner/state/random_state.rs
+++ b/rapidhash/src/inner/state/random_state.rs
@@ -29,7 +29,7 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// let mut map = HashMap::with_hasher(RandomState::default());
 /// map.insert(42, "the answer");
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct RandomState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> {
     seed: u64,
 


### PR DESCRIPTION
Hi! This would help avoid some boilerplate Debug implementations in map impls that can't derive Debug themselves without an impl for the RandomState they're using.