### PR TITLE
Add rapidhash_v3_with_seed and seed-path benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ assert_eq!(hasher.hash_one(b"hello world"), 3348275917668072623);
 Fully compatible with the C++ rapidhash algorithms. Methods are provided for all rapidhash V1, V2, and V3 (with micro/nano) variants. These are stable functions whose output will not change between crate versions.
 
 ```rust
-use rapidhash::v3::{rapidhash_v3_seeded, rapidhash_v3_file_seeded, RapidSecrets, RapidStreamHasherV3};
+use rapidhash::v3::{rapidhash_v3_seeded, rapidhash_v3_with_seed, rapidhash_v3_file_seeded, RapidSecrets, RapidStreamHasherV3};
 
 /// Set your global hashing secrets.
 /// - For HashDoS resistance, choose a randomized secret.
@@ -54,6 +54,7 @@ const SECRETS: RapidSecrets = RapidSecrets::seed(0x123456);
 
 // Bulk: hash a complete byte slice.
 let bulk = rapidhash_v3_seeded(b"hello world", &SECRETS);
+let bulk_cpp_seed = rapidhash_v3_with_seed(b"hello world", 1234);
 
 // Stream: write chunks of any size, same output regardless of chunk boundaries.
 let mut hasher = RapidStreamHasherV3::new(&SECRETS);

--- a/rapidhash-bench/benches/bench/main.rs
+++ b/rapidhash-bench/benches/bench/main.rs
@@ -1,9 +1,10 @@
 use criterion::{criterion_group, criterion_main};
 
 mod basic;
+mod compiled;
 mod emails;
 mod rng;
-mod compiled;
+mod seed_path;
 mod state;
 mod streaming;
 
@@ -13,6 +14,7 @@ criterion_group!(
     emails::bench,
     rng::bench,
     compiled::bench,
+    seed_path::bench,
     state::bench,
     streaming::bench,
 );

--- a/rapidhash-bench/benches/bench/seed_path.rs
+++ b/rapidhash-bench/benches/bench/seed_path.rs
@@ -1,0 +1,318 @@
+//! Benchmark seeded v3 call paths:
+//! - pointer-based seeded API: `rapidhash_v3_seeded(data, &RapidSecrets)`
+//! - seed-by-value API: `rapidhash_v3_with_seed(data, seed)`
+
+use criterion::measurement::WallTime;
+use criterion::{BenchmarkGroup, Criterion, Throughput};
+use rand::{Rng, SeedableRng};
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::hint::black_box;
+
+const RUNTIME_SEED: u64 = 0x1234_5678_9abc_def0;
+const LOOKUP_SEED: u64 = 0x0f1e_2d3c_4b5a_6978;
+const INPUT_POOL: usize = 1024;
+const LOOKUP_MAP_SIZE: usize = 10_000;
+const LOOKUP_QUERY_COUNT: usize = 20_000;
+
+static LOOKUP_SECRETS: rapidhash::v3::RapidSecrets =
+    rapidhash::v3::RapidSecrets::seed_cpp(LOOKUP_SEED);
+
+#[derive(Clone, Eq, PartialEq)]
+struct BytesKey(Box<[u8]>);
+
+impl Hash for BytesKey {
+    #[inline(always)]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SeededPointerPath {
+    secrets: rapidhash::v3::RapidSecrets,
+}
+
+#[derive(Clone, Copy)]
+struct SeedByValuePath {
+    seed: u64,
+}
+
+#[inline(never)]
+fn hash_seeded_pointer_from_state(data: &[u8], state: &SeededPointerPath) -> u64 {
+    rapidhash::v3::rapidhash_v3_seeded(data, &state.secrets)
+}
+
+#[inline(never)]
+fn hash_with_seed_from_state(data: &[u8], state: &SeedByValuePath) -> u64 {
+    rapidhash::v3::rapidhash_v3_with_seed(data, state.seed)
+}
+
+#[derive(Clone, Copy)]
+struct V3SeededPointerBuildHasher {
+    secrets: rapidhash::v3::RapidSecrets,
+}
+
+#[derive(Clone, Copy)]
+struct V3SeededPointerHasher {
+    secrets: rapidhash::v3::RapidSecrets,
+    hash: u64,
+}
+
+impl BuildHasher for V3SeededPointerBuildHasher {
+    type Hasher = V3SeededPointerHasher;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        V3SeededPointerHasher {
+            secrets: self.secrets,
+            hash: 0,
+        }
+    }
+}
+
+impl Hasher for V3SeededPointerHasher {
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = rapidhash::v3::rapidhash_v3_seeded(bytes, &self.secrets);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct V3WithSeedBuildHasher {
+    seed: u64,
+}
+
+#[derive(Clone, Copy)]
+struct V3WithSeedHasher {
+    seed: u64,
+    hash: u64,
+}
+
+impl BuildHasher for V3WithSeedBuildHasher {
+    type Hasher = V3WithSeedHasher;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        V3WithSeedHasher {
+            seed: self.seed,
+            hash: 0,
+        }
+    }
+}
+
+impl Hasher for V3WithSeedHasher {
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = rapidhash::v3::rapidhash_v3_with_seed(bytes, self.seed);
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct V3UnseededBuildHasher;
+
+#[derive(Clone, Copy, Default)]
+struct V3UnseededHasher {
+    hash: u64,
+}
+
+impl BuildHasher for V3UnseededBuildHasher {
+    type Hasher = V3UnseededHasher;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        V3UnseededHasher { hash: 0 }
+    }
+}
+
+impl Hasher for V3UnseededHasher {
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = rapidhash::v3::rapidhash_v3(bytes);
+    }
+}
+
+fn sample_inputs(len: usize) -> Vec<Box<[u8]>> {
+    debug_assert!(INPUT_POOL.is_power_of_two());
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0x9f2d_6d10_733a_12bd ^ len as u64);
+    (0..INPUT_POOL)
+        .map(|_| {
+            let mut input = vec![0u8; len];
+            rng.fill(input.as_mut_slice());
+            input.into_boxed_slice()
+        })
+        .collect()
+}
+
+fn sample_lookup_dataset() -> (Vec<BytesKey>, Vec<BytesKey>) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xc4d3_22f1_91aa_18e3);
+    let map_keys: Vec<BytesKey> = (0..LOOKUP_MAP_SIZE)
+        .map(|_| {
+            let len = rng.random_range(2..=8);
+            let mut data = vec![0u8; len];
+            rng.fill(data.as_mut_slice());
+            BytesKey(data.into_boxed_slice())
+        })
+        .collect();
+
+    let hit_queries: Vec<BytesKey> = (0..LOOKUP_QUERY_COUNT)
+        .map(|_| map_keys[rng.random_range(0..map_keys.len())].clone())
+        .collect();
+
+    (map_keys, hit_queries)
+}
+
+fn bench_hash_path<F>(group: &mut BenchmarkGroup<'_, WallTime>, label: &str, len: usize, hash: F)
+where
+    F: Fn(&[u8]) -> u64 + Copy,
+{
+    let name = format!("{label}/len_{len}");
+    let inputs = sample_inputs(len);
+    let mut idx: usize = 0;
+    group.throughput(Throughput::Elements(1));
+    group.bench_function(&name, move |b| {
+        b.iter(|| {
+            idx = idx.wrapping_add(1);
+            let input = &inputs[idx & (INPUT_POOL - 1)];
+            black_box(hash(black_box(input.as_ref())))
+        });
+    });
+}
+
+fn build_map<B: BuildHasher>(build_hasher: B, map_keys: &[BytesKey]) -> HashMap<BytesKey, u32, B> {
+    let mut map = HashMap::with_capacity_and_hasher(map_keys.len(), build_hasher);
+    for (idx, key) in map_keys.iter().cloned().enumerate() {
+        map.insert(key, idx as u32);
+    }
+    map
+}
+
+fn bench_lookup_path<B: BuildHasher + Clone>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    build_hasher: B,
+    map_keys: &[BytesKey],
+    hit_queries: &[BytesKey],
+) {
+    let map = build_map(build_hasher, map_keys);
+
+    group.throughput(Throughput::Elements(hit_queries.len() as u64));
+    group.bench_function(format!("{label}/lookup_hit"), |b| {
+        b.iter(|| {
+            let mut sum = 0u64;
+            for key in hit_queries {
+                if let Some(v) = map.get(black_box(key)) {
+                    sum = sum.wrapping_add(*v as u64);
+                }
+            }
+            black_box(sum)
+        });
+    });
+}
+
+pub fn bench(c: &mut Criterion) {
+    let pointer_path = SeededPointerPath {
+        secrets: rapidhash::v3::RapidSecrets::seed_cpp(RUNTIME_SEED),
+    };
+    let by_value_path = SeedByValuePath { seed: RUNTIME_SEED };
+
+    let mut short_group = c.benchmark_group("seed-path/short");
+    short_group.warm_up_time(std::time::Duration::from_millis(250));
+    short_group.measurement_time(std::time::Duration::from_millis(1000));
+    short_group.sample_size(100);
+
+    for len in 1..=16 {
+        bench_hash_path(
+            &mut short_group,
+            "v3_unseeded",
+            len,
+            rapidhash::v3::rapidhash_v3,
+        );
+        bench_hash_path(&mut short_group, "v3_with_seed_zero", len, |data| {
+            rapidhash::v3::rapidhash_v3_with_seed(data, 0)
+        });
+        bench_hash_path(&mut short_group, "v3_with_seed_const", len, |data| {
+            rapidhash::v3::rapidhash_v3_with_seed(data, RUNTIME_SEED)
+        });
+        bench_hash_path(&mut short_group, "v3_with_seed_runtime", len, |data| {
+            hash_with_seed_from_state(data, black_box(&by_value_path))
+        });
+        bench_hash_path(&mut short_group, "v3_seeded_pointer", len, |data| {
+            hash_seeded_pointer_from_state(data, black_box(&pointer_path))
+        });
+    }
+    short_group.finish();
+
+    let mut long_group = c.benchmark_group("seed-path/long");
+    long_group.warm_up_time(std::time::Duration::from_millis(250));
+    long_group.measurement_time(std::time::Duration::from_millis(1500));
+    long_group.sample_size(100);
+    for len in [64usize, 256, 1024] {
+        bench_hash_path(
+            &mut long_group,
+            "v3_unseeded",
+            len,
+            rapidhash::v3::rapidhash_v3,
+        );
+        bench_hash_path(&mut long_group, "v3_with_seed_zero", len, |data| {
+            rapidhash::v3::rapidhash_v3_with_seed(data, 0)
+        });
+        bench_hash_path(&mut long_group, "v3_with_seed_const", len, |data| {
+            rapidhash::v3::rapidhash_v3_with_seed(data, RUNTIME_SEED)
+        });
+        bench_hash_path(&mut long_group, "v3_with_seed_runtime", len, |data| {
+            hash_with_seed_from_state(data, black_box(&by_value_path))
+        });
+        bench_hash_path(&mut long_group, "v3_seeded_pointer", len, |data| {
+            hash_seeded_pointer_from_state(data, black_box(&pointer_path))
+        });
+    }
+    long_group.finish();
+
+    let (map_keys, hit_queries) = sample_lookup_dataset();
+    let mut lookup_group = c.benchmark_group("seed-path/lookup");
+    lookup_group.warm_up_time(std::time::Duration::from_millis(250));
+    lookup_group.measurement_time(std::time::Duration::from_millis(1500));
+    lookup_group.sample_size(60);
+    lookup_group.sampling_mode(criterion::SamplingMode::Flat);
+
+    bench_lookup_path(
+        &mut lookup_group,
+        "v3_unseeded",
+        V3UnseededBuildHasher,
+        &map_keys,
+        &hit_queries,
+    );
+    bench_lookup_path(
+        &mut lookup_group,
+        "v3_with_seed",
+        V3WithSeedBuildHasher { seed: LOOKUP_SEED },
+        &map_keys,
+        &hit_queries,
+    );
+    bench_lookup_path(
+        &mut lookup_group,
+        "v3_seeded_pointer",
+        V3SeededPointerBuildHasher {
+            secrets: LOOKUP_SECRETS,
+        },
+        &map_keys,
+        &hit_queries,
+    );
+    lookup_group.finish();
+}

--- a/rapidhash/src/v3/mod.rs
+++ b/rapidhash/src/v3/mod.rs
@@ -23,9 +23,9 @@ pub use seed::*;
 mod tests {
     extern crate std;
 
-    use rand::Rng;
-    use crate::util::macros::{compare_to_c, flip_bit_trial};
     use super::*;
+    use crate::util::macros::{compare_to_c, flip_bit_trial};
+    use rand::Rng;
 
     flip_bit_trial!(flip_bit_trial_v3, rapidhash_v3_inline::<true, false, false>);
     flip_bit_trial!(flip_bit_trial_v3_micro, rapidhash_v3_micro_inline::<true, false>);
@@ -33,6 +33,43 @@ mod tests {
     compare_to_c!(compare_to_c_v3, rapidhash_v3_inline::<true, false, false>, rapidhash_v3_inline::<true, true, false>, rapidhashcc_v3);
     compare_to_c!(compare_to_c_v3_micro, rapidhash_v3_micro_inline::<true, false>, rapidhash_v3_micro_inline::<true, false>, rapidhashcc_v3_micro);
     compare_to_c!(compare_to_c_v3_nano, rapidhash_v3_nano_inline::<true, false>, rapidhash_v3_nano_inline::<true, false>, rapidhashcc_v3_nano);
+
+    #[test]
+    fn with_seed_zero_matches_unseeded_v3() {
+        let mut rng = rand::rng();
+        for len in 0..=2048 {
+            let mut data = std::vec![0; len];
+            rng.fill(&mut data[..]);
+            assert_eq!(rapidhash_v3_with_seed(&data, 0), rapidhash_v3(&data), "Mismatch on len {len}");
+        }
+    }
+
+    #[test]
+    fn with_seed_matches_seed_cpp_path() {
+        let mut rng = rand::rng();
+        let mut seed_corpus = std::vec![
+            0,
+            1,
+            2,
+            3,
+            0x0123_4567_89ab_cdef,
+            0xfedc_ba98_7654_3210,
+            u64::MAX,
+        ];
+        for _ in 0..64 {
+            seed_corpus.push(rng.random());
+        }
+
+        for len in 0..=512 {
+            let mut data = std::vec![0; len];
+            rng.fill(&mut data[..]);
+            for seed in &seed_corpus {
+                let expected = rapidhash_v3_seeded(&data, &RapidSecrets::seed_cpp(*seed));
+                let actual = rapidhash_v3_with_seed(&data, *seed);
+                assert_eq!(actual, expected, "Mismatch on len {len} seed {seed}");
+            }
+        }
+    }
 
     /// Compare the main rapidhash version matches micro (80 btyes) and nano (48 bytes) up to
     /// the expected length.

--- a/rapidhash/src/v3/rapid_const.rs
+++ b/rapidhash/src/v3/rapid_const.rs
@@ -19,6 +19,20 @@ pub const fn rapidhash_v3_seeded(data: &[u8], secrets: &RapidSecrets) -> u64 {
     rapidhash_v3_inline::<true, false, false>(data, secrets)
 }
 
+/// Rapidhash V3 with a custom seed and default C++-compatible secrets.
+///
+/// This is equivalent to:
+/// `rapidhash_v3_seeded(data, &RapidSecrets::seed_cpp(seed))`.
+///
+/// For `seed = 0`, this outputs the same hash as [`rapidhash_v3`].
+///
+/// This API matches the C reference `rapidhash_withSeed(data, len, seed)` call pattern.
+#[inline(always)]
+pub const fn rapidhash_v3_with_seed(data: &[u8], seed: u64) -> u64 {
+    let premixed_seed = seed ^ rapid_mix::<false>(seed ^ DEFAULT_RAPID_SECRETS.secrets[2], DEFAULT_RAPID_SECRETS.secrets[1]);
+    rapidhash_core::<true, false, false>(premixed_seed, &DEFAULT_RAPID_SECRETS.secrets, data)
+}
+
 /// Rapidhash V3 a single byte stream, matching the C++ implementation.
 ///
 /// Is marked with `#[inline(always)]` to force the compiler to inline and optimize the method.


### PR DESCRIPTION
## Summary
- Add `rapidhash_v3_with_seed(data, seed)` to V3 using default C++-compatible secrets.
- Add correctness tests:
  - `rapidhash_v3_with_seed(data, 0) == rapidhash_v3(data)`
  - `rapidhash_v3_with_seed(data, s) == rapidhash_v3_seeded(data, &RapidSecrets::seed_cpp(s))`
- Add a benchmark suite for seeded call paths:
  - `seed-path/short` (1..=16)
  - `seed-path/long` (64/256/1024)
  - `seed-path/lookup` (HashMap lookup-hit workload)

## Codegen Rationale
`rapidhash_v3_seeded(data, &RapidSecrets)` can force secret values through pointer loads in hot short-key paths.

`rapidhash_v3_with_seed(data, seed)` keeps default secrets constant in the function body so they can be emitted as immediates; only the runtime seed remains dynamic.

## Minimal Repro In This PR
From committed benchmark code in `rapidhash-bench/benches/bench/seed_path.rs`:

```rust
#[inline(never)]
fn hash_seeded_pointer_from_state(data: &[u8], state: &SeededPointerPath) -> u64 {
    rapidhash::v3::rapidhash_v3_seeded(data, &state.secrets)
}

#[inline(never)]
fn hash_with_seed_from_state(data: &[u8], state: &SeedByValuePath) -> u64 {
    rapidhash::v3::rapidhash_v3_with_seed(data, state.seed)
}
```

Build + disassemble those exact symbols:

```sh
cargo bench -p rapidhash-bench --bench bench --features bench --no-run
BIN=$(ls target/release/deps/bench-* | head -n1)
objdump -d --demangle "$BIN" | sed -n '/<bench::seed_path::hash_seeded_pointer_from_state>:/,/^$/p'
objdump -d --demangle "$BIN" | sed -n '/<bench::seed_path::hash_with_seed_from_state>:/,/^$/p'
```

## Assembly Evidence
Pointer-seeded path (`bench::seed_path::hash_seeded_pointer_from_state`) loads secrets from state memory:

```asm
130346: mov    (%rdx),%rdi
...
13039c: mov    0x10(%rdx),%rdi
```

By-value seeded path (`bench::seed_path::hash_with_seed_from_state`) has default secrets as immediates (no secret dereference from `%rdx`):

```asm
130296: movabs $0x4b33a62ed433d4a3,%rax
1302a3: movabs $0x8bb84b93962eacc9,%rsi
```

This is the key change: extra secret loads are removed from the hot path.

## Compiler-Settings Check
This is not an artifact of weak optimization settings in this repo:

- Workspace `Cargo.toml` sets both `[profile.release]` and `[profile.bench]` to:
  - `lto = "fat"`
  - `codegen-units = 1`
- The disassembly above is from `cargo bench ... --no-run` under that configuration.

So the pointer-secrets load behavior still appears even with fat LTO and single CGU.

## Why This API Still Matters
In downstream libraries using rapidhash with C-compatible seeding, maintainers typically cannot control end-user compiler/profile flags.

Providing `rapidhash_v3_with_seed(data, seed)` gives an API shape that consistently enables constant-inlined default secrets independent of downstream build configuration.

## Benchmark Snapshot (this branch)
Pinned core (`taskset -c 0`) Criterion runs:

- `seed-path/lookup` (lookup_hit)
  - `v3_with_seed`: 82.238 us
  - `v3_seeded_pointer`: 90.486 us
  - ~9.1% faster for `v3_with_seed`
- `seed-path/short`
  - len=7: 1.4098 ns vs 1.5390 ns (~8.4% faster)
  - len=16: 1.5074 ns vs 1.5858 ns (~4.9% faster)

Long-key benchmarks are near parity/noise-level differences as expected.
