### PR TITLE
Overhaul RandomState and GlobalState entropy logic

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -157,4 +157,4 @@ jobs:
       - name: Compile and run tests
         run: cargo build -p rapidhash --no-default-features --lib --target thumbv6m-none-eabi
       - name: Compile with a getrandom custom backend
-        run: RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build -p rapidhash --no-default-features --features getrandom --lib --target thumbv6m-none-eabi
+        run: RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build -p rapidhash --no-default-features --features getrandom_04 --lib --target thumbv6m-none-eabi

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -136,10 +136,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Rust dependency cache
         uses: Swatinem/rust-cache@v2
-      - name: Install wasm target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm targets
+        run: rustup target add wasm32-unknown-unknown wasm32-wasip1
       - name: Compile and run tests
         run: cargo build -p rapidhash --target wasm32-unknown-unknown
+      - name: Run wasm behaviour tests (with and without getrandom)
+        run: cargo test -p rapidhash-bench-wasm --test wasm_behaviour --no-fail-fast
 
   test-no-atomics:
     # Check that a no-atomics target compiles, but it sadly can't run tests
@@ -154,3 +156,5 @@ jobs:
         run: rustup target add thumbv6m-none-eabi
       - name: Compile and run tests
         run: cargo build -p rapidhash --no-default-features --lib --target thumbv6m-none-eabi
+      - name: Compile with a getrandom custom backend
+        run: RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build -p rapidhash --no-default-features --features getrandom --lib --target thumbv6m-none-eabi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,22 @@
 ## 4.5.0 (Unreleased)
 
 ### Additions
-- **`getrandom` feature**: opt-in seeding of the hasher seeds and secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This replaces the `rand` feature and enables true HashDoS resistance on targets with no ambient entropy or ASLR:
+- **`getrandom_04` feature**: opt-in seeding of the hasher seeds and secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This replaces the `rand` feature and enables true HashDoS resistance on targets with no ambient entropy or ASLR:
   - `wasm32-wasip1`/`wasm32-wasip2`: enabling the feature is sufficient; entropy comes from the WASI host.
   - `wasm32-unknown-unknown` (browser/node): additionally requires getrandom's `wasm_js` backend, enabled by the top-level binary. Building without the backend is a compile error rather than a silent fallback to deterministic seeding.
   - Embedded/`no_std` targets with a hardware RNG: register a getrandom [custom backend](https://docs.rs/getrandom/0.3/getrandom/#custom-backend). On targets without atomic pointer support (e.g. `thumbv6m-none-eabi`), each `RandomState` draws a fresh random seed per instance, restoring minimal HashDoS resistance where there previously was none.
+- **`getrandom_03` feature**: the same as the `getrandom_04` feature, but using getrandom v0.3 to preserve the rapidhash MSRV 1.71.
 
 ### Fixes
 - `RandomState` no longer produces duplicate seeds across threads whose stacks are recycled by the OS. Each thread's seed counter is now initialized from a global thread counter mixed with the process-wide random seed, instead of relying on the (frequently re-used) stack address alone.
 - Better randomness handling on `no_std` targets and targets without atomics.
 
 ### Changes
-- The `rand` feature is now a deprecated alias for `std` + `getrandom`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference depending on enabled features. The `rand` feature will be removed in a future major version.
-- Documented how to achieve true seed randomization on wasm32 and embedded targets in the `RandomState` and `GlobalState` docs, and documented the one remaining gap: `GlobalState` on targets without atomic pointer support cannot be randomized, and `RandomState` with `getrandom` should be preferred there.
+- The `rand` feature is now a deprecated alias for `std` + `getrandom_03`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference depending on enabled features. The `rand` feature will be removed in a future major version.
+- Documented how to achieve true seed randomization on wasm32 and embedded targets in the `RandomState` and `GlobalState` docs, and documented the one remaining gap: `GlobalState` on targets without atomic pointer support cannot be randomized, and `RandomState` with `getrandom_04` should be preferred there.
 
 ### Testing
-- Added wasm32 behavioural tests, run through wasmtime in CI: without `getrandom` (`wasm32-unknown-unknown`) seeding is asserted to be fully deterministic across instances, and with `getrandom` (`wasm32-wasip1` + WASI entropy) seeds and secrets are asserted to differ between instances.
+- Added wasm32 behavioural tests, run through wasmtime in CI: without `getrandom` (`wasm32-unknown-unknown`) seeding is asserted to be fully deterministic across instances, and with `getrandom_04` (`wasm32-wasip1` + WASI entropy) seeds and secrets are asserted to differ between instances.
 - Added a 1024-thread seed uniqueness test covering OS thread-stack recycling.
 
 ## 4.4.2 (20260627)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,31 @@
 ## Planned for 5.0.0
 - Remove `Copy` from State types (eg. `RandomState`) to match the `std` hasher API.
 - Make the `rapidhash_v3_file_inline` buffer size configurable.
-- Upgrade `rand` and `rand_core` to v0.10.
+- Upgrade `rand_core` to v0.10.
 - Replace `premix_seed` in `RapidSecrets::reseed` with `rapidhash_seed`.
+
+## 4.5.0 (Unreleased)
+
+### Additions
+- **`getrandom` feature**: opt-in seeding of the hasher seeds and secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This replaces the `rand` feature and enables true HashDoS resistance on targets with no ambient entropy or ASLR:
+  - `wasm32-wasip1`/`wasm32-wasip2`: enabling the feature is sufficient; entropy comes from the WASI host.
+  - `wasm32-unknown-unknown` (browser/node): additionally requires getrandom's `wasm_js` backend, enabled by the top-level binary. Building without the backend is a compile error rather than a silent fallback to deterministic seeding.
+  - Embedded/`no_std` targets with a hardware RNG: register a getrandom [custom backend](https://docs.rs/getrandom/0.3/getrandom/#custom-backend). On targets without atomic pointer support (e.g. `thumbv6m-none-eabi`), each `RandomState` draws a fresh random seed per instance, restoring minimal HashDoS resistance where there previously was none.
+
+### Fixes
+- `RandomState` no longer produces duplicate seeds across threads whose stacks are recycled by the OS. Each thread's seed counter is now initialized from a global thread counter mixed with the process-wide random seed, instead of relying on the (frequently re-used) stack address alone.
+- The per-map seed on `no_std` targets without atomics now mixes in the stack pointer as intended; previously it compiled to a constant.
+- The seed counters now use wrapping addition, fixing a potential "attempt to add with overflow" panic in debug builds.
+- The global seed and global secrets are now derived from the shared process randomness with domain separation, so recovering one no longer trivially reveals the other. Each secret is also independently re-mixed from the process randomness, so a single leaked secret no longer derives the remaining secrets.
+
+### Changes
+- The `rand` feature is now a deprecated alias for `std` + `getrandom`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference. The `rand` feature will be removed in a future major version.
+- Per-map seeds on `no_std` targets with atomics now start from the process-wide random seed, so getrandom/ASLR entropy reaches every seed rather than only the secrets.
+- Documented how to achieve true seed randomization on wasm32 and embedded targets in the `RandomState` and `GlobalState` docs, and documented the one remaining gap: `GlobalState` on targets without atomic pointer support cannot be randomized, and `RandomState` with `getrandom` should be preferred there.
+
+### Testing
+- Added wasm32 behavioural tests, run through wasmtime in CI: without `getrandom` (`wasm32-unknown-unknown`) seeding is asserted to be fully deterministic across instances, and with `getrandom` (`wasm32-wasip1` + WASI entropy) seeds and secrets are asserted to differ between instances.
+- Added a 1024-thread seed uniqueness test covering OS thread-stack recycling.
 
 ## 4.4.2 (20260627)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,10 @@
 
 ### Fixes
 - `RandomState` no longer produces duplicate seeds across threads whose stacks are recycled by the OS. Each thread's seed counter is now initialized from a global thread counter mixed with the process-wide random seed, instead of relying on the (frequently re-used) stack address alone.
-- The per-map seed on `no_std` targets without atomics now mixes in the stack pointer as intended; previously it compiled to a constant.
-- The seed counters now use wrapping addition, fixing a potential "attempt to add with overflow" panic in debug builds.
-- The global seed and global secrets are now derived from the shared process randomness with domain separation, so recovering one no longer trivially reveals the other. Each secret is also independently re-mixed from the process randomness, so a single leaked secret no longer derives the remaining secrets.
+- Better randomness handling on `no_std` targets and targets without atomics.
 
 ### Changes
-- The `rand` feature is now a deprecated alias for `std` + `getrandom`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference. The `rand` feature will be removed in a future major version.
-- Per-map seeds on `no_std` targets with atomics now start from the process-wide random seed, so getrandom/ASLR entropy reaches every seed rather than only the secrets.
+- The `rand` feature is now a deprecated alias for `std` + `getrandom`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference depending on enabled features. The `rand` feature will be removed in a future major version.
 - Documented how to achieve true seed randomization on wasm32 and embedded targets in the `RandomState` and `GlobalState` docs, and documented the one remaining gap: `GlobalState` on targets without atomic pointer support cannot be randomized, and `RandomState` with `getrandom` should be preferred there.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ echo "example" | rapidhash --v3
 
 - `default`: `std`
 - `std`: Enables the `RapidHashMap` and `RapidHashSet` helper types, and lets `RandomState` and `GlobalState` seed their secrets from the standard library's secure RNG (rather than ASLR alone) and initialize slightly faster via a thread-local seed counter. Disabling it keeps the crate `no_std`, but seeding then falls back to weaker ASLR-based entropy.
-- `rand`: **Deprecated.** Now an alias for `std` + `getrandom`, and will be removed in a future major version.
 - `getrandom`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
+- `rand`: **Deprecated.** Now an alias for `std` + `getrandom`, and will be removed in a future major version.
 - `rng`: Enables `RapidRng`, a fast, non-cryptographic PRNG based on rapidrng. Includes the `rand_core` crate dependency.
 - `unsafe`: Uses unsafe pointer arithmetic to skip some unnecessary bounds checks for a small 3-4% performance improvement.
 - `nightly`: Enable nightly-only features for even faster hashing, such as overriding `Hasher::write_str` and likely hints.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ echo "example" | rapidhash --v3
 
 - `default`: `std`
 - `std`: Enables the `RapidHashMap` and `RapidHashSet` helper types, and lets `RandomState` and `GlobalState` seed their secrets from the standard library's secure RNG (rather than ASLR alone) and initialize slightly faster via a thread-local seed counter. Disabling it keeps the crate `no_std`, but seeding then falls back to weaker ASLR-based entropy.
-- `getrandom`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate v0.4, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
-- `rand`: **Deprecated.** Now an alias for `std` + `getrandom`, and will be removed in a future major version.
+- `getrandom_04`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate v0.4, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
+- `getrandom_03`: The same as `getrandom_04`, but using getrandom v0.3.
+- `rand`: **Deprecated.** Now an alias for `std` + `getrandom_03`, and will be removed in a future major version. getrandom v0.3 is chosen to preserve the MSRV 1.71.
 - `rng`: Enables `RapidRng`, a fast, non-cryptographic PRNG based on rapidrng. Includes the `rand_core` crate dependency.
 - `unsafe`: Uses unsafe pointer arithmetic to skip some unnecessary bounds checks for a small 3-4% performance improvement.
 - `nightly`: Enable nightly-only features for even faster hashing, such as overriding `Hasher::write_str` and likely hints.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ echo "example" | rapidhash --v3
 ## Features
 
 - `default`: `std`
-- `std`: Enables the `RapidHashMap` and `RapidHashSet` helper types.
-- `rand`: Enables using the `rand` library to more securely initialize `RandomState`. Includes the `rand` crate dependency.
+- `std`: Enables the `RapidHashMap` and `RapidHashSet` helper types, and lets `RandomState` and `GlobalState` seed their secrets from the standard library's secure RNG (rather than ASLR alone) and initialize slightly faster via a thread-local seed counter. Disabling it keeps the crate `no_std`, but seeding then falls back to weaker ASLR-based entropy.
+- `rand`: **Deprecated.** Now an alias for `std` + `getrandom`, and will be removed in a future major version.
+- `getrandom`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
 - `rng`: Enables `RapidRng`, a fast, non-cryptographic PRNG based on rapidrng. Includes the `rand_core` crate dependency.
 - `unsafe`: Uses unsafe pointer arithmetic to skip some unnecessary bounds checks for a small 3-4% performance improvement.
 - `nightly`: Enable nightly-only features for even faster hashing, such as overriding `Hasher::write_str` and likely hints.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ echo "example" | rapidhash --v3
 
 - `default`: `std`
 - `std`: Enables the `RapidHashMap` and `RapidHashSet` helper types, and lets `RandomState` and `GlobalState` seed their secrets from the standard library's secure RNG (rather than ASLR alone) and initialize slightly faster via a thread-local seed counter. Disabling it keeps the crate `no_std`, but seeding then falls back to weaker ASLR-based entropy.
-- `getrandom`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
+- `getrandom`: Seeds the `RandomState` and `GlobalState` secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate v0.4, without requiring `std`. This is the only way to get HashDoS resistance on targets with no ambient entropy or ASLR, such as `wasm32-unknown-unknown` in the browser (which additionally requires enabling getrandom's `wasm_js` backend from the top-level binary crate).
 - `rand`: **Deprecated.** Now an alias for `std` + `getrandom`, and will be removed in a future major version.
 - `rng`: Enables `RapidRng`, a fast, non-cryptographic PRNG based on rapidrng. Includes the `rand_core` crate dependency.
 - `unsafe`: Uses unsafe pointer arithmetic to skip some unnecessary bounds checks for a small 3-4% performance improvement.

--- a/rapidhash-bench-wasm/Cargo.toml
+++ b/rapidhash-bench-wasm/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [features]
 nightly = ["rapidhash/nightly", "foldhash/nightly"]
+getrandom = ["rapidhash/getrandom"]  # used by the wasm32-wasip1 behaviour tests
 
 [dependencies]
 rapidhash = { path = "../rapidhash", default-features = false }
@@ -21,6 +22,7 @@ fxhash = "0.2.1"
 [dev-dependencies]
 criterion = { version = "0.8.1", default-features = false, features = ["rayon", "cargo_bench_support"] }
 wasmtime = "46.0.0"
+wasmtime-wasi = "46.0.0"
 
 [lints]
 workspace = true

--- a/rapidhash-bench-wasm/Cargo.toml
+++ b/rapidhash-bench-wasm/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 
 [features]
 nightly = ["rapidhash/nightly", "foldhash/nightly"]
-getrandom = ["rapidhash/getrandom"]  # used by the wasm32-wasip1 behaviour tests
+getrandom = ["rapidhash/getrandom_04"]  # used by the wasm32-wasip1 behaviour tests
 
 [dependencies]
 rapidhash = { path = "../rapidhash", default-features = false }

--- a/rapidhash-bench-wasm/src/lib.rs
+++ b/rapidhash-bench-wasm/src/lib.rs
@@ -44,6 +44,20 @@ bench_wasm_4kb!(bench_wasm_foldhash_f_4kb, foldhash::fast::RandomState);
 bench_wasm_4kb!(bench_wasm_default_4kb, std::hash::RandomState);
 bench_wasm_4kb!(bench_wasm_fxhash_4kb, fxhash::FxBuildHasher);
 
+/// Hash a fixed value with a fresh `RandomState`, used to test per-map seed uniqueness and
+/// cross-instance determinism on wasm.
+#[unsafe(no_mangle)]
+pub extern "C" fn test_wasm_random_state() -> u64 {
+    rapidhash::fast::RandomState::default().hash_one(42u64)
+}
+
+/// Hash a fixed value with the process-wide `GlobalState`, used to test that the one-time
+/// global seed/secret initialization works on wasm.
+#[unsafe(no_mangle)]
+pub extern "C" fn test_wasm_global_state() -> u64 {
+    rapidhash::fast::GlobalState::default().hash_one(42u64)
+}
+
 /// Simulate hashing fictional (id, email) pairs, where email is len 6..60 bytes.
 fn profile_hash_tuple<B: BuildHasher + Default>() -> u64 {
     let builder = B::default();

--- a/rapidhash-bench-wasm/tests/wasm_behaviour.rs
+++ b/rapidhash-bench-wasm/tests/wasm_behaviour.rs
@@ -1,0 +1,159 @@
+//! Behavioural tests for rapidhash seeding on wasm32, run through wasmtime.
+//!
+//! wasm32 has full atomics but no ASLR or threads, so rapidhash's seeding entropy depends
+//! entirely on whether the `getrandom` feature is enabled and the host provides entropy.
+//! These tests pin down both configurations:
+//!
+//! - **Without `getrandom`** (`wasm32-unknown-unknown`): seeding is fully deterministic.
+//!   Within an instance, per-map `RandomState` seeds must still be unique (the seed counter
+//!   works) and `GlobalState` must initialize once and stay stable; across fresh instances,
+//!   all outputs are identical because there is no entropy source. This documents that the
+//!   default configuration has NO HashDoS resistance on wasm.
+//! - **With `getrandom`** (`wasm32-wasip1`, where the WASI host supplies entropy via
+//!   `random_get`): outputs must DIFFER across fresh instances, proving the entropy reaches
+//!   both the global secrets and the per-map seeds.
+//!
+//! Browser/node environments (`wasm32-unknown-unknown` + getrandom's `wasm_js` backend) can't
+//! be tested under wasmtime as they need a JS host, but they share the same getrandom code
+//! path as the WASI test. Enabling `getrandom` on wasm32-unknown-unknown without the backend
+//! flag is a compile error (getrandom refuses to build), so it cannot silently regress to the
+//! deterministic behaviour.
+
+use std::path::PathBuf;
+use std::process::Command;
+use wasmtime::*;
+
+/// Build the wasm module for the given target, returning `None` (test skipped) when the
+/// required rustup target isn't installed.
+fn build_wasm(target: &str, features: &[&str]) -> Option<PathBuf> {
+    let installed = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .ok()?;
+    if !String::from_utf8_lossy(&installed.stdout)
+        .lines()
+        .any(|line| line.trim() == target)
+    {
+        return None;
+    }
+
+    let mut args = vec![
+        "build",
+        "--release",
+        "--package", "rapidhash-bench-wasm",
+        "--target", target,
+    ];
+    for feature in features {
+        args.extend_from_slice(&["--features", feature]);
+    }
+
+    let status = Command::new("cargo")
+        .args(&args)
+        .env("RUSTFLAGS", "") // explicitly clear any bench flags
+        .status()
+        .expect("Failed to run cargo build for wasm target");
+    assert!(status.success(), "Failed to compile for the {target} target");
+
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target"));
+    let path = target_dir.join(target).join("release/rapidhash_bench_wasm.wasm");
+    assert!(path.exists(), "Expected output wasm file not found at {}", path.display());
+    Some(path)
+}
+
+/// A fresh module instance: fresh linear memory, so all of rapidhash's statics are reset.
+struct WasmInstance<T: 'static> {
+    store: Store<T>,
+    random_state: TypedFunc<(), u64>,
+    global_state: TypedFunc<(), u64>,
+}
+
+impl<T: 'static> WasmInstance<T> {
+    fn new(linker: &Linker<T>, module: &Module, data: T) -> Self {
+        let mut store = Store::new(linker.engine(), data);
+        let instance = linker.instantiate(&mut store, module).unwrap();
+
+        // wasip1 cdylibs are reactor-style modules that may export an initializer.
+        if let Some(initialize) = instance.get_func(&mut store, "_initialize") {
+            initialize.call(&mut store, &[], &mut []).unwrap();
+        }
+
+        let random_state = instance.get_typed_func::<(), u64>(&mut store, "test_wasm_random_state").unwrap();
+        let global_state = instance.get_typed_func::<(), u64>(&mut store, "test_wasm_global_state").unwrap();
+        Self { store, random_state, global_state }
+    }
+
+    fn random_state(&mut self) -> u64 {
+        self.random_state.call(&mut self.store, ()).unwrap()
+    }
+
+    fn global_state(&mut self) -> u64 {
+        self.global_state.call(&mut self.store, ()).unwrap()
+    }
+}
+
+#[test]
+fn test_wasm_seeding_without_getrandom_is_deterministic() {
+    let Some(path) = build_wasm("wasm32-unknown-unknown", &[]) else {
+        eprintln!("skipping: wasm32-unknown-unknown target not installed (rustup target add wasm32-unknown-unknown)");
+        return;
+    };
+
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, &path).unwrap();
+    let linker: Linker<()> = Linker::new(&engine);
+
+    let mut a = WasmInstance::new(&linker, &module, ());
+
+    // The seed counter must produce a distinct seed per RandomState, even without entropy.
+    let a_random1 = a.random_state();
+    let a_random2 = a.random_state();
+    assert_ne!(a_random1, a_random2, "RandomState instances should have unique seeds within a wasm instance");
+
+    // GlobalState initializes once and every subsequent call must agree.
+    let a_global1 = a.global_state();
+    let a_global2 = a.global_state();
+    assert_eq!(a_global1, a_global2, "GlobalState should be stable within a wasm instance");
+
+    // A fresh instance resets all statics; with no entropy source on wasm32-unknown-unknown
+    // the outputs are identical across instances. This documents the platform's limitation:
+    // there is NO HashDoS resistance in this configuration.
+    let mut b = WasmInstance::new(&linker, &module, ());
+    assert_eq!(a_random1, b.random_state(), "wasm32 seeding without getrandom is expected to be deterministic across instances");
+    assert_eq!(a_global1, b.global_state(), "wasm32 global secrets without getrandom are expected to be deterministic across instances");
+}
+
+#[test]
+fn test_wasm_seeding_with_getrandom_is_randomized() {
+    use wasmtime_wasi::p1::WasiP1Ctx;
+
+    let Some(path) = build_wasm("wasm32-wasip1", &["getrandom"]) else {
+        eprintln!("skipping: wasm32-wasip1 target not installed (rustup target add wasm32-wasip1)");
+        return;
+    };
+
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, &path).unwrap();
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |ctx| ctx).unwrap();
+
+    let wasi_ctx = || wasmtime_wasi::WasiCtxBuilder::new().build_p1();
+
+    let mut a = WasmInstance::new(&linker, &module, wasi_ctx());
+
+    // The uniqueness and stability guarantees hold as before.
+    let a_random1 = a.random_state();
+    let a_random2 = a.random_state();
+    assert_ne!(a_random1, a_random2, "RandomState instances should have unique seeds within a wasm instance");
+
+    let a_global1 = a.global_state();
+    let a_global2 = a.global_state();
+    assert_eq!(a_global1, a_global2, "GlobalState should be stable within a wasm instance");
+
+    // A fresh instance re-seeds from host entropy: with getrandom enabled, both the global
+    // secrets and the per-map seeds must now differ between instances ("boots").
+    let mut b = WasmInstance::new(&linker, &module, wasi_ctx());
+    assert_ne!(a_random1, b.random_state(), "wasm32 seeding with getrandom should differ across instances");
+    assert_ne!(a_global1, b.global_state(), "wasm32 global secrets with getrandom should differ across instances");
+}

--- a/rapidhash-msrv/Cargo.toml
+++ b/rapidhash-msrv/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 std = ["rapidhash/std"]
 rng = ["rapidhash/rng"]
 rand = ["rapidhash/rand"]
-getrandom = ["rapidhash/getrandom"]
+getrandom = ["rapidhash/getrandom_03"]
 
 [dependencies]
 rapidhash = { path = "../rapidhash", default-features = false }

--- a/rapidhash-msrv/Cargo.toml
+++ b/rapidhash-msrv/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 std = ["rapidhash/std"]
 rng = ["rapidhash/rng"]
 rand = ["rapidhash/rand"]
+getrandom = ["rapidhash/getrandom"]
 
 [dependencies]
 rapidhash = { path = "../rapidhash", default-features = false }

--- a/rapidhash/Cargo.toml
+++ b/rapidhash/Cargo.toml
@@ -34,7 +34,7 @@ unsafe = []  # enable unsafe pointer arithmetic; this is used to check for bound
 [dependencies]
 rustversion = "1.0"
 rand_core = { version = "0.9", default-features = false, optional = true }
-getrandom = { version = "0.3", default-features = false, optional = true }
+getrandom = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
 rapidhash-c = { path = "../rapidhash-c" }

--- a/rapidhash/Cargo.toml
+++ b/rapidhash/Cargo.toml
@@ -25,16 +25,22 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["std"]
 std = []  # enable std library for RapidHashMap and RapidHashSet helpers
-rand = ["std", "getrandom"]  # deprecated: alias for std + getrandom (the old feature implied std), will be removed in a future major version
-getrandom = ["dep:getrandom"]  # seed hasher secrets from OS/platform entropy, incl. no_std and wasm (wasm32-unknown-unknown also needs getrandom's wasm_js backend enabled by the top-level binary)
+rand = ["std", "getrandom_03"]  # deprecated: alias for std + getrandom (the old feature implied std), will be removed in a future major version
+getrandom_04 = ["dep:getrandom_04"]  # seed hasher secrets from OS/platform entropy using getrandom v0.4, incl. no_std and wasm (wasm32-unknown-unknown also needs getrandom's wasm_js backend enabled by the top-level binary)
+getrandom_03 = ["dep:getrandom_03"]  # the same as getrandom_04, but using getrandom v0.3
 rng = ["dep:rand_core"]  # enable RapidRng, a rand Rng-compatible fast PRNG using rapidrng
 nightly = []  # enable nightly features, faster str hashing and likely/unlikely hints
 unsafe = []  # enable unsafe pointer arithmetic; this is used to check for bounds-check regressions
 
+# dev note: we separate our getrandom feature versions to avoid pinning the rapidhash crate version
+# to a specific getrandom version, otherwise we'd need to perform a major version bump for any
+# getrandom version bumps. It also lets us keep MSRV 1.71 while supporting newer getrandom versions.
+
 [dependencies]
 rustversion = "1.0"
 rand_core = { version = "0.9", default-features = false, optional = true }
-getrandom = { version = "0.4", default-features = false, optional = true }
+getrandom_04 = { version = "0.4", package = "getrandom", default-features = false, optional = true }
+getrandom_03 = { version = "0.3", package = "getrandom", default-features = false, optional = true }
 
 [dev-dependencies]
 rapidhash-c = { path = "../rapidhash-c" }

--- a/rapidhash/Cargo.toml
+++ b/rapidhash/Cargo.toml
@@ -25,15 +25,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["std"]
 std = []  # enable std library for RapidHashMap and RapidHashSet helpers
-rand = ["dep:rand", "std"]  # enable the rand library for initializing RandomState
+rand = ["std", "getrandom"]  # deprecated: alias for std + getrandom (the old feature implied std), will be removed in a future major version
+getrandom = ["dep:getrandom"]  # seed hasher secrets from OS/platform entropy, incl. no_std and wasm (wasm32-unknown-unknown also needs getrandom's wasm_js backend enabled by the top-level binary)
 rng = ["dep:rand_core"]  # enable RapidRng, a rand Rng-compatible fast PRNG using rapidrng
 nightly = []  # enable nightly features, faster str hashing and likely/unlikely hints
 unsafe = []  # enable unsafe pointer arithmetic; this is used to check for bounds-check regressions
 
 [dependencies]
 rustversion = "1.0"
-rand = { version = "0.9", optional = true }
 rand_core = { version = "0.9", default-features = false, optional = true }
+getrandom = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 rapidhash-c = { path = "../rapidhash-c" }

--- a/rapidhash/src/collections.rs
+++ b/rapidhash/src/collections.rs
@@ -2,6 +2,14 @@ use crate::fast::RandomState;
 
 /// A [`std::collections::HashMap`] that uses the [`crate::fast::RandomState`] hasher.
 ///
+/// # Performance
+///
+/// `RapidHashMap` should be significantly faster than [`std::collections::HashMap`] when using the
+/// default hasher. When creating many `RapidHashMap`s in a tight loop, you may want to consider
+/// using [`crate::fast::GlobalState`] instead, which is faster to instantiate because it re-uses
+/// the same randomized seed and secrets between instantiations, but still randomizes them on
+/// program start.
+///
 /// # Example
 /// ```
 /// use rapidhash::{HashMapExt, RapidHashMap};

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -395,6 +395,7 @@ pub(crate) mod secrets {
     mod tests {
         extern crate std;
 
+        use std::arch::is_s390x_feature_detected;
         use std::collections::BTreeSet;
         use super::*;
 
@@ -446,7 +447,7 @@ pub(crate) mod secrets {
         }
 
         #[test]
-        #[cfg(any(feature = "std", feature = "getrandom"))]
+        #[cfg(any(feature = "std", feature = "getrandom_04", feature = "getrandom_03"))]
         fn test_generate_random() {
             let random1 = super::generate_random();
             let random2 = super::generate_random();
@@ -455,7 +456,7 @@ pub(crate) mod secrets {
 
         #[test]
         #[ignore]
-        #[cfg(not(any(feature = "std", feature = "getrandom")))]
+        #[cfg(not(any(feature = "std", feature = "getrandom_04", feature = "getrandom_03")))]
         fn test_generate_random_no_std_hardcoded() {
             // I use this to check we're getting random values between test runs by flipping this
             // to an "assert_eq" ...

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -45,10 +45,10 @@ pub(crate) mod seed {
                 let mut seed = cell.get();
                 #[cfg(all(feature = "std", target_has_atomic = "ptr"))] {
                     if seed == 0 {
-                        seed = init_thread_seed();
+                        seed = init_thread_seed(arbitrary);
                     }
                 }
-                seed = seed.wrapping_add(DEFAULT_SECRETS[0] ^ arbitrary);  // simple weyl counter, like rapidrand
+                seed = seed.wrapping_add(DEFAULT_SECRETS[0]);
                 cell.set(seed);
                 seed
             });
@@ -100,10 +100,18 @@ pub(crate) mod seed {
     /// (OS randomness under std) into every per-map seed. One relaxed `fetch_add` plus a mix:
     /// no syscalls, so thread-per-request servers only pay a few cycles per thread.
     #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
-    fn init_thread_seed() -> u64 {
+    #[cold]
+    fn init_thread_seed(arbitrary: u64) -> u64 {
         use core::sync::atomic::{AtomicUsize, Ordering};
         static THREAD_COUNTER: AtomicUsize = AtomicUsize::new(1);
-        let thread_counter = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed) as u64;
+
+        // Lossy add our ASLR offset to the counter. We believe this is less contentious than a
+        // fetch_add. We accept a lossy add because the only reason one thread's value will be lost
+        // is if it's overwritten by another thread, meaning if this thread is cached and reused, it
+        // will read a different thread_counter value on each instantiation.
+        let mut thread_counter = THREAD_COUNTER.load(Ordering::Relaxed) as u64;
+        thread_counter = thread_counter.wrapping_add(arbitrary);
+        THREAD_COUNTER.store(thread_counter as usize, Ordering::Relaxed);
 
         let global_seed = super::secrets::GlobalSecrets::new().get_global_seed();
         rapid_mix_np::<false>(thread_counter ^ DEFAULT_SECRETS[3], global_seed ^ DEFAULT_SECRETS[4])
@@ -344,7 +352,11 @@ pub(crate) mod secrets {
             // the rust standard library doesn't directly expose the secure randomness it feeds its
             // hashers, but we can still indirectly use it by running a single hash.
             use std::hash::{BuildHasher, Hasher};
-            let mut hasher = std::hash::RandomState::new().build_hasher();
+
+            // using the old import path for MSRV 1.71 compatibility
+            use std::collections::hash_map::RandomState as StdRandomState;
+
+            let mut hasher = StdRandomState::new().build_hasher();
             hasher.write(b"");
             return hasher.finish()
         }

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -19,12 +19,19 @@ pub(crate) mod seed {
 
     #[inline]
     pub fn get_seed() -> u64 {
-        // this would all be so much easier if the rust std exposed how it does RandomState
-        // we take the stack pointer as a rather poor but cheap source of entropy
+        // We take the stack pointer as a rather poor (but cheap!) source of entropy. The first
+        // call benefits greatly from ASLR, but subsequent calls may have the same stack pointer,
+        // and so we do further work below (on systems that support it!).
+        //
+        // `mut` is unused on targets where no block below applies (no std, atomics, or getrandom).
+        #[allow(unused_mut)]
         let mut seed = 0;
         let arbitrary = core::ptr::addr_of!(seed) as u64;
 
-        // with std we avoid using global atomics
+        // With std we avoid using global atomics on the hot path, choosing a thread-local seed
+        // counter. The counter must start from a unique value per thread: the OS recycles thread
+        // stacks, so two threads whose first call happens at the same (reused) stack address
+        // would otherwise produce identical seed sequences.
         #[cfg(feature = "std")] {
             use core::cell::Cell;
 
@@ -36,27 +43,70 @@ pub(crate) mod seed {
 
             seed = RANDOM_SEED.with(|cell| {
                 let mut seed = cell.get();
-                seed = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[1], arbitrary ^ DEFAULT_SECRETS[0]);
+                #[cfg(all(feature = "std", target_has_atomic = "ptr"))] {
+                    if seed == 0 {
+                        seed = init_thread_seed();
+                    }
+                }
+                seed = seed.wrapping_add(DEFAULT_SECRETS[0] ^ arbitrary);  // simple weyl counter, like rapidrand
                 cell.set(seed);
                 seed
             });
         }
 
-        // without std we fall back to a global atomic and accept the chance of
-        // race conditions, but don't consider this an issue
+        // Without std we fall back to a global atomic and accept the chance of
+        // race conditions, but two racing threads should have different stack pointers,
+        // and so should generate distinct seeds.
         //
         // Most targets without atomics can still do atomic load/store, but just can't
-        // do atomic compare-and-swap instructions. So this should still compile/work...
-        #[cfg(not(feature = "std"))] {
+        // do atomic compare-and-swap instructions, so we'd prefer if rust had a better way to
+        // narrow down exactly what atomic functionality is available on a platform. Here, a
+        // platform without CAS but does have load/store will miss out.
+        #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))] {
             use core::sync::atomic::{AtomicUsize, Ordering};
             static RANDOM_SEED: AtomicUsize = AtomicUsize::new(0);
 
             seed = RANDOM_SEED.load(Ordering::Relaxed) as u64;
-            seed = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[1], arbitrary ^ DEFAULT_SECRETS[0]);
+            if seed == 0 {
+                // First call in the process: start the counter from the global seed, so that
+                // per-map seeds include the one-time entropy (getrandom when enabled,
+                // otherwise ASLR-derived).
+                seed = super::secrets::GlobalSecrets::new().get_global_seed();
+            }
+            seed = seed.wrapping_add(DEFAULT_SECRETS[0] ^ arbitrary);
             RANDOM_SEED.store(seed as usize, Ordering::Relaxed);
         }
 
-        seed ^ rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[1])
+        // Without std or atomics there is no way to store counter state between calls, but with
+        // the getrandom feature each RandomState can draw a fresh seed straight from the entropy
+        // source (e.g. a custom getrandom backend over an embedded device's hardware RNG).
+        // Slower than the counter paths above, but the only randomisation these targets have.
+        #[cfg(all(not(feature = "std"), not(target_has_atomic = "ptr"), feature = "getrandom"))] {
+            if let Ok(random) = getrandom::u64() {
+                seed = random;
+            }
+        }
+
+        // If neither atomics, std, nor getrandom were available, we're sadly left hoping that
+        // stack pointer ASLR has been sufficient randomness. In that case, two RandomStates may
+        // end up with the same seed, but as long as ASLR is intact, they should be different.
+        seed ^ rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[2], arbitrary ^ DEFAULT_SECRETS[1])
+    }
+
+    /// Derive the starting value for a thread's seed counter, called once per thread.
+    ///
+    /// A global counter guarantees every thread starts from a distinct point even when thread
+    /// stacks are recycled, and mixing in the global seed folds the process's one-time entropy
+    /// (OS randomness under std) into every per-map seed. One relaxed `fetch_add` plus a mix:
+    /// no syscalls, so thread-per-request servers only pay a few cycles per thread.
+    #[cfg(all(feature = "std", target_has_atomic = "ptr"))]
+    fn init_thread_seed() -> u64 {
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        static THREAD_COUNTER: AtomicUsize = AtomicUsize::new(1);
+        let thread_counter = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed) as u64;
+
+        let global_seed = super::secrets::GlobalSecrets::new().get_global_seed();
+        rapid_mix_np::<false>(thread_counter ^ DEFAULT_SECRETS[3], global_seed ^ DEFAULT_SECRETS[4])
     }
 
     #[cfg(test)]
@@ -69,15 +119,31 @@ pub(crate) mod seed {
             let seed2 = get_seed();
             assert_ne!(seed1, seed2, "get_seed should return different values on subsequent calls");
         }
+
+        #[test]
+        fn test_seed_collision_is_unlikely_across_threads() {
+            extern crate std;
+            use std::collections::BTreeSet;
+
+            const THREADS: usize = 1024;
+            let seeds: BTreeSet<u64> = (0..THREADS)
+                .map(|_| std::thread::spawn(get_seed).join().unwrap())
+                .collect();
+
+            // If threads were properly independent this would be 8; the counter reset
+            // + stack reuse collapses them, so we expect duplicates.
+            assert_eq!(seeds.len(), THREADS, "expected no seed collisions across threads, got {} unique", seeds.len());
+        }
     }
 }
 
+// TODO: use compile-time generated constants here
 #[cfg(not(target_has_atomic = "ptr"))]
 pub(crate) mod secrets {
     #[inline(always)]
     pub fn get_secrets() -> &'static [u64; 7] {
-        // This is a no-op for platforms that do not support atomic pointers.
-        // The secrets are not used, so we return an empty slice.
+        // Platforms without atomic pointer (CAS) support cannot safely randomize a global,
+        // so we fall back to the default rapidhash secrets.
         &crate::inner::seed::DEFAULT_RAPID_SECRETS.secrets
     }
 
@@ -115,7 +181,8 @@ pub(crate) mod secrets {
 pub(crate) mod secrets {
     use core::cell::UnsafeCell;
     use core::sync::atomic::{AtomicUsize, Ordering};
-    use crate::util::mix::rapid_mix;
+    use crate::inner::mix_np::rapid_mix_np;
+    use crate::v1::DEFAULT_SEED;
     use super::DEFAULT_SECRETS;
 
     /// A hacky sync-friendly, std-free, OnceCell that sadly needs unsafe inspired by foldhash's
@@ -181,13 +248,21 @@ pub(crate) mod secrets {
         GlobalSecrets::new().get()
     }
 
+    /// Initialize the global seed and secrets, racing other threads for the right to do so.
+    ///
+    /// All randomness generation and derivation happens *before* the CAS, so the window where
+    /// the state is `Initializing` is only a handful of stores. Losing threads spin until the
+    /// winner publishes; on any preemptive OS this is bounded and tiny. The remaining hazard is
+    /// a single-core system without preemption — e.g. an interrupt handler creating a hasher
+    /// while the interrupted code was mid-initialization — which would spin forever. That is
+    /// unavoidable without heap allocation while `get()` hands out `&'static` secrets; such
+    /// systems should create a hasher once at startup, before enabling interrupts.
     #[cold]
     #[inline(never)]
     fn initialize_secrets() {
-        let seed = generate_random();
-        let secrets = create_secrets(seed);
-
-        const INITIALIZED: usize = SecretStorageStates::Initialized as usize;
+        let randomness = generate_random();
+        let seed = rapid_mix_np::<false>(randomness ^ DEFAULT_SECRETS[0], DEFAULT_SEED);
+        let secrets = create_secrets(randomness);
 
         loop {
             match SECRET_STORAGE.state.compare_exchange_weak(
@@ -207,7 +282,7 @@ pub(crate) mod secrets {
                 }
 
                 // Another thread has initialized for us, so we're done.
-                Err(INITIALIZED) => {
+                Err(s) if s == SecretStorageStates::Initialized as usize => {
                     return;
                 }
 
@@ -219,7 +294,8 @@ pub(crate) mod secrets {
         }
     }
 
-    fn create_secrets(mut seed: u64) -> [u64; 7] {
+    fn create_secrets(seed: u64) -> [u64; 7] {
+        let mut state = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[2], DEFAULT_SECRETS[1]);
         let mut secrets = [0u64; 7];
 
         for i in 0..secrets.len() {
@@ -227,22 +303,22 @@ pub(crate) mod secrets {
             const MI: u64 = 0xFFFF << 24;
             const LO: u64 = 0xFFFF;
 
-            seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[0], DEFAULT_SECRETS[i]);
+            state = rapid_mix_np::<false>(state ^ DEFAULT_SECRETS[0], seed ^ DEFAULT_SECRETS[i]);
 
             // ensure at least one high, middle, and low bit is set for a semi-decent secret
-            if (seed & HI) == 0 {
-                seed |= 1u64 << 63;
+            if (state & HI) == 0 {
+                state |= 1u64 << 63;
             }
 
-            if (seed & MI) == 0 {
-                seed |= 1u64 << 31;
+            if (state & MI) == 0 {
+                state |= 1u64 << 31;
             }
 
-            if (seed & LO) == 0 {
-                seed |= 1u64;
+            if (state & LO) == 0 {
+                state |= 1u64;
             }
 
-            secrets[i] = seed;
+            secrets[i] = state;
         }
 
         secrets
@@ -250,48 +326,45 @@ pub(crate) mod secrets {
 
     /// Generate a random number, trying our best to make this a good random number.
     ///
-    /// To only be called sparingly as it's fairly slow.
-    pub fn generate_random() -> u64 {
-        #[cfg(feature = "rand")]
-        {
-            rand::random()
+    /// This method should only be relied upon _once per process_ to create randomness, as without
+    /// the `getrandom` or `std` features it relies entirely on ASLR to produce randomness.
+    pub(crate) fn generate_random() -> u64 {
+        // The getrandom feature sources entropy directly from the OS/platform, and is the only
+        // real entropy source on wasm32 (via getrandom's `wasm_js` backend) and many no_std
+        // targets. It takes priority over std, as std's RandomState silently falls back to
+        // fixed keys on targets without entropy (e.g. wasm32-unknown-unknown).
+        #[cfg(feature = "getrandom")] {
+            if let Ok(random) = getrandom::u64() {
+                return random;
+            }
+            // otherwise fall through to the weaker sources below
         }
 
-        #[cfg(not(feature = "rand"))]
-        {
-            // trying our best to generate a good random number on all platforms
+        #[cfg(feature = "std")] {
+            // the rust standard library doesn't directly expose the secure randomness it feeds its
+            // hashers, but we can still indirectly use it by running a single hash.
+            use std::hash::{BuildHasher, Hasher};
+            let mut hasher = std::hash::RandomState::new().build_hasher();
+            hasher.write(b"");
+            return hasher.finish()
+        }
+
+        #[cfg(not(feature = "std"))] {
+            // Trying our best to generate a good random number on all platforms by hoping for ASLR
+            // and noting that this randomness only works once, all other randomness must be derived
+            // from this single u64 of randomness. Calling get_random() twice in the same thread or
+            // process can return the same u64 value.
             let mut seed = DEFAULT_SECRETS[0];
             let stack_ptr = core::ptr::addr_of!(seed) as u64;
             let static_ptr = &DEFAULT_SECRETS as *const _ as usize as u64;
             let function_ptr = generate_random as *const () as usize as u64;
 
-            seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[4], stack_ptr ^ DEFAULT_SECRETS[1]);
-            seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[5], function_ptr ^ DEFAULT_SECRETS[2]);
-            seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[6], static_ptr ^ DEFAULT_SECRETS[3]);
+            seed = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[4], stack_ptr ^ DEFAULT_SECRETS[1]);
+            seed = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[5], function_ptr ^ DEFAULT_SECRETS[2]);
+            seed = rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[6], static_ptr ^ DEFAULT_SECRETS[3]);
 
-            #[cfg(feature = "std")]
-            {
-                // we can allocate to add extra noise
-                let box_ptr = &*Box::new(1u64) as *const _ as usize as u64;
-                seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[4], box_ptr ^ DEFAULT_SECRETS[1]);
-            }
-
-            #[cfg(all(
-                feature = "std",
-                not(any(
-                    miri,
-                    all(target_family = "wasm", target_os = "unknown"),
-                    target_os = "zkvm"
-                ))
-            ))]
-            {
-                // we can use the system time for extra noise
-                seed = crate::rng::rapidrng_time(&mut seed);
-            }
-
-            // final avalanche step
-            seed = rapid_mix::<true>(seed ^ DEFAULT_SECRETS[6], DEFAULT_SECRETS[0]);
-            seed
+            // final avalanche mix step
+            return rapid_mix_np::<false>(seed ^ DEFAULT_SECRETS[6], DEFAULT_SECRETS[0])
         }
     }
 
@@ -350,11 +423,21 @@ pub(crate) mod secrets {
         }
 
         #[test]
-        #[cfg(feature = "std")]
+        #[cfg(any(feature = "std", feature = "getrandom"))]
         fn test_generate_random() {
             let random1 = super::generate_random();
             let random2 = super::generate_random();
             assert_ne!(random1, random2, "generate_random should return different values on subsequent calls");
+        }
+
+        #[test]
+        #[ignore]
+        #[cfg(not(any(feature = "std", feature = "getrandom")))]
+        fn test_generate_random_no_std_hardcoded() {
+            // I use this to check we're getting random values between test runs by flipping this
+            // to an "assert_eq" ...
+            let random1 = super::generate_random();
+            assert_ne!(random1, 10848721480813500213, "a hardcoded test that ASLR randomisation is working");
         }
     }
 }

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -138,8 +138,6 @@ pub(crate) mod seed {
                 .map(|_| std::thread::spawn(get_seed).join().unwrap())
                 .collect();
 
-            // If threads were properly independent this would be 8; the counter reset
-            // + stack reuse collapses them, so we expect duplicates.
             assert_eq!(seeds.len(), THREADS, "expected no seed collisions across threads, got {} unique", seeds.len());
         }
     }

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -81,8 +81,14 @@ pub(crate) mod seed {
         // the getrandom feature each RandomState can draw a fresh seed straight from the entropy
         // source (e.g. a custom getrandom backend over an embedded device's hardware RNG).
         // Slower than the counter paths above, but the only randomisation these targets have.
-        #[cfg(all(not(feature = "std"), not(target_has_atomic = "ptr"), feature = "getrandom"))] {
-            if let Ok(random) = getrandom::u64() {
+        #[cfg(all(not(feature = "std"), not(target_has_atomic = "ptr"), feature = "getrandom_04"))] {
+            if let Ok(random) = getrandom_04::u64() {
+                seed = random;
+            }
+        }
+
+        #[cfg(all(not(feature = "std"), not(target_has_atomic = "ptr"), not(feature = "getrandom_04"), feature = "getrandom_03"))] {
+            if let Ok(random) = getrandom_03::u64() {
                 seed = random;
             }
         }
@@ -339,8 +345,15 @@ pub(crate) mod secrets {
         // real entropy source on wasm32 (via getrandom's `wasm_js` backend) and many no_std
         // targets. It takes priority over std, as std's RandomState silently falls back to
         // fixed keys on targets without entropy (e.g. wasm32-unknown-unknown).
-        #[cfg(feature = "getrandom")] {
-            if let Ok(random) = getrandom::u64() {
+        #[cfg(feature = "getrandom_04")] {
+            if let Ok(random) = getrandom_04::u64() {
+                return random;
+            }
+            // otherwise fall through to the weaker sources below
+        }
+
+        #[cfg(all(feature = "getrandom_03", not(feature = "getrandom_04")))] {
+            if let Ok(random) = getrandom_03::u64() {
                 return random;
             }
             // otherwise fall through to the weaker sources below

--- a/rapidhash/src/inner/state/global_state.rs
+++ b/rapidhash/src/inner/state/global_state.rs
@@ -5,9 +5,37 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 
 /// A [`BuildHasher`] that uses a global seed and secrets, randomized only once on startup.
 ///
-/// The global secrets are randomized on the first instantiation, and then every subsequent instance
-/// of GlobalState will re-use the same seed and secrets, ensuring consistent hash outputs for the
-/// duration of the program.
+/// The global seed and secrets are randomized on the first instantiation, and then every subsequent
+/// instance of GlobalState will re-use the same seed and secrets, ensuring consistent hash outputs
+/// for the duration of the program.
+///
+/// The one-time randomization is derived from OS/platform entropy when the `getrandom` feature is
+/// enabled, or the standard library's secure RNG when the `std` feature is enabled, falling back
+/// to ASLR and weaker entropy sources otherwise. Because every
+/// instance shares a single seed and secret set, `GlobalState` only offers minimal HashDoS
+/// resistance: an attacker cannot predict the secrets, but every map in the process shares the same
+/// collision structure. Prefer [`RandomState`](crate::fast::RandomState) when each map should be
+/// seeded independently.
+///
+/// See [`RandomState`](crate::fast::RandomState)'s portability docs for enabling true
+/// randomisation on wasm32 and embedded targets via the `getrandom` feature.
+///
+/// # Performance
+///
+/// `GlobalState` is faster and smaller than `RandomState` while still providing some minimal DoS
+/// resistance, and so may be preferable to `RandomState` when instantiating many hashmaps in a
+/// tight loop.
+///
+/// # Example
+/// ```rust
+/// use std::collections::HashMap;
+/// use std::hash::Hasher;
+///
+/// use rapidhash::fast::GlobalState;
+///
+/// let mut map = HashMap::with_hasher(GlobalState::default());
+/// map.insert(42, "the answer");
+/// ```
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct GlobalState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> {
     /// The global secrets is a zero-sized type to keep HashMap<K, V, RandomState> small.
@@ -17,12 +45,21 @@ pub struct GlobalState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT:
 impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> GlobalState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
     /// Create a new global state with a global seed and secrets.
     ///
-    /// The seed and secrets will be randomized on the first instantiation of `GlobalState`, but all
-    /// subsequent instances will share the same seed and secrets.
+    /// The seed and secrets are randomized once, on the first instantiation of any `GlobalState`,
+    /// and then cached for the lifetime of the program; all subsequent instances share them. With
+    /// the `std` feature the one-time randomization is derived from the standard library's secure
+    /// RNG; without `std` it falls back to ASLR and other weaker sources of entropy.
+    ///
+    /// Because every instance shares the same seed and secrets, all maps in the process share the
+    /// same collision structure. Use [`RandomState`](crate::fast::RandomState) if you need each map
+    /// to be seeded independently.
     ///
     /// On platforms which do not support atomic pointers, the secrets will be the default rapidhash
-    /// secrets, which are not randomized. Therefore, **targets without atomic pointer support will
-    /// not have minimal HashDoS resistance guarantees**.
+    /// secrets, which are not randomized. Therefore, **`GlobalState` on targets without atomic
+    /// pointer support has no HashDoS resistance guarantees**: there is nowhere to store a
+    /// randomized value, so even the `getrandom` feature cannot help. Prefer
+    /// [`RandomState`](crate::fast::RandomState) with the `getrandom` feature on these targets,
+    /// which draws a fresh random seed per instance instead.
     #[inline(always)]
     pub fn new() -> Self {
         Self {

--- a/rapidhash/src/inner/state/global_state.rs
+++ b/rapidhash/src/inner/state/global_state.rs
@@ -9,7 +9,7 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// instance of GlobalState will re-use the same seed and secrets, ensuring consistent hash outputs
 /// for the duration of the program.
 ///
-/// The one-time randomization is derived from OS/platform entropy when the `getrandom` feature is
+/// The one-time randomization is derived from OS/platform entropy when the `getrandom_04` feature is
 /// enabled, or the standard library's secure RNG when the `std` feature is enabled, falling back
 /// to ASLR and weaker entropy sources otherwise. Because every
 /// instance shares a single seed and secret set, `GlobalState` only offers minimal HashDoS
@@ -57,8 +57,8 @@ impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTE
     /// On platforms which do not support atomic pointers, the secrets will be the default rapidhash
     /// secrets, which are not randomized. Therefore, **`GlobalState` on targets without atomic
     /// pointer support has no HashDoS resistance guarantees**: there is nowhere to store a
-    /// randomized value, so even the `getrandom` feature cannot help. Prefer
-    /// [`RandomState`](crate::fast::RandomState) with the `getrandom` feature on these targets,
+    /// randomized value, so even the `getrandom_04` feature cannot help. Prefer
+    /// [`RandomState`](crate::fast::RandomState) with the `getrandom_04` feature on these targets,
     /// which draws a fresh random seed per instance instead.
     #[inline(always)]
     pub fn new() -> Self {

--- a/rapidhash/src/inner/state/random_state.rs
+++ b/rapidhash/src/inner/state/random_state.rs
@@ -24,31 +24,31 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// # Portability
 ///
 /// On most target platforms, the secrets are randomly initialized once and cached globally for the
-/// lifetime of the program. With the `getrandom` feature this uses OS/platform entropy directly;
+/// lifetime of the program. With the `getrandom_04` feature this uses OS/platform entropy directly;
 /// with `std` it uses the standard library's secure RNG; with neither it falls back to ASLR-based
 /// entropy alone. A fresh seed is generated for each new instance of `RandomState` from a
 /// thread-local or global counter mixed with ASLR entropy.
 ///
 /// Some targets have no ambient entropy or ASLR at all, and seeding on them is otherwise fully
-/// deterministic between boots. Enable the `getrandom` feature to get true randomisation for
+/// deterministic between boots. Enable the `getrandom_04` feature to get true randomisation for
 /// HashDoS resistance on these targets:
 ///
-/// - **wasm32 with WASI** (`wasm32-wasip1`/`wasm32-wasip2`): enabling rapidhash's `getrandom`
+/// - **wasm32 with WASI** (`wasm32-wasip1`/`wasm32-wasip2`): enabling rapidhash's `getrandom_04`
 ///   feature is sufficient; entropy comes from the WASI host.
-/// - **wasm32 in the browser or node** (`wasm32-unknown-unknown`): enable rapidhash's `getrandom`
-///   feature, add `getrandom = { version = "0.3", features = ["wasm_js"] }` to the top-level
+/// - **wasm32 in the browser or node** (`wasm32-unknown-unknown`): enable rapidhash's `getrandom_04`
+///   feature, add `getrandom = { version = "0.4", features = ["wasm_js"] }` to the top-level
 ///   binary's dependencies, and build with `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`.
 ///   Without the backend flag the build fails with instructions, rather than silently
 ///   falling back to deterministic seeding.
-/// - **Embedded and other `no_std` targets with a hardware RNG**: enable rapidhash's `getrandom`
-///   feature and register a [custom backend](https://docs.rs/getrandom/0.3/getrandom/#custom-backend)
+/// - **Embedded and other `no_std` targets with a hardware RNG**: enable rapidhash's `getrandom_04`
+///   feature and register a [custom backend](https://docs.rs/getrandom/0.4/getrandom/#custom-backend)
 ///   that reads from the platform's RNG.
 ///
 /// Older or exotic platforms that getrandom does not support can also use the custom backend
 /// mechanism to supply their own entropy source.
 ///
 /// On targets without atomic pointer support (e.g. `thumbv6m-none-eabi`), the global secrets
-/// cannot be randomized and fall back to the default secrets. With the `getrandom` feature each
+/// cannot be randomized and fall back to the default secrets. With the `getrandom_04` feature each
 /// `RandomState` still draws a fresh random per-map seed directly from the entropy source,
 /// retaining minimal HashDoS resistance; without it these platforms have none. If stronger
 /// support for these platforms is important to your application, please raise a GitHub issue.
@@ -79,17 +79,17 @@ impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTE
     /// counter is initialized from the process-wide random seed and a global thread counter;
     /// without `std` it uses a global atomic counter initialized from the process-wide random
     /// seed. On targets with neither, each instance draws its seed from getrandom when the
-    /// `getrandom` feature is enabled, or falls back to ASLR alone.
+    /// `getrandom_04` feature is enabled, or falls back to ASLR alone.
     ///
     /// The secrets are randomized once and then cached globally for the lifetime of the program.
-    /// The one-time randomization is derived from OS/platform entropy with the `getrandom`
+    /// The one-time randomization is derived from OS/platform entropy with the `getrandom_04`
     /// feature, or the standard library's secure RNG with the `std` feature (the same source
     /// `std` uses to seed its own hashers); with neither it falls back to mixing ASLR and other
     /// weaker sources of entropy.
     ///
     /// On platforms that do not support atomic pointers, the secrets will be the default rapidhash
     /// secrets, which are not randomized. Therefore, **targets without atomic pointer support only
-    /// have minimal HashDoS resistance when the `getrandom` feature provides random seeds**.
+    /// have minimal HashDoS resistance when the `getrandom_04` feature provides random seeds**.
     #[inline]
     pub fn new() -> Self {
         Self {

--- a/rapidhash/src/inner/state/random_state.rs
+++ b/rapidhash/src/inner/state/random_state.rs
@@ -9,16 +9,49 @@ use crate::inner::seeding::secrets::GlobalSecrets;
 /// This is designed to provide some HashDoS resistance by using a random seed per hashmap, and
 /// a global random set of secrets.
 ///
+/// # Performance
+///
+/// Enabling the `std` feature will make `RandomState` slightly faster to initialize by avoiding
+/// a global atomic load/store and using thread-locals instead.
+///
+/// Note that `GlobalState` will be even faster to initialize than `RandomState`, as it does not
+/// generate a new seed for every instantiation. `GlobalState` also randomizes the seed and secrets
+/// on the first instantiation, so it can still provide minimal DoS resistance, but then re-uses
+/// that same randomized seed and secrets for subsequent instantiations. If you are creating many
+/// instances of `RandomState` in a tight loop, you may want to consider using `GlobalState`
+/// instead.
+///
 /// # Portability
 ///
 /// On most target platforms, the secrets are randomly initialized once and cached globally for the
-/// lifetime of the program using a mix of ASLR and other entropy sources. The seed is randomly
-/// initialized for each new instance of `RandomState` using only ASLR and a mixing step.
+/// lifetime of the program. With the `getrandom` feature this uses OS/platform entropy directly;
+/// with `std` it uses the standard library's secure RNG; with neither it falls back to ASLR-based
+/// entropy alone. A fresh seed is generated for each new instance of `RandomState` from a
+/// thread-local or global counter mixed with ASLR entropy.
 ///
-/// On targets without atomic pointer support, the global secrets will not be randomized, and
-/// instead will fall back to the default secrets. This means these platforms will not have minimal
-/// HashDoS resistance guarantees. If this is important for your application, please raise a GitHub
-/// issue to improve support for these platforms.
+/// Some targets have no ambient entropy or ASLR at all, and seeding on them is otherwise fully
+/// deterministic between boots. Enable the `getrandom` feature to get true randomisation for
+/// HashDoS resistance on these targets:
+///
+/// - **wasm32 with WASI** (`wasm32-wasip1`/`wasm32-wasip2`): enabling rapidhash's `getrandom`
+///   feature is sufficient; entropy comes from the WASI host.
+/// - **wasm32 in the browser or node** (`wasm32-unknown-unknown`): enable rapidhash's `getrandom`
+///   feature, add `getrandom = { version = "0.3", features = ["wasm_js"] }` to the top-level
+///   binary's dependencies, and build with `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`.
+///   Without the backend flag the build fails with instructions, rather than silently
+///   falling back to deterministic seeding.
+/// - **Embedded and other `no_std` targets with a hardware RNG**: enable rapidhash's `getrandom`
+///   feature and register a [custom backend](https://docs.rs/getrandom/0.3/getrandom/#custom-backend)
+///   that reads from the platform's RNG.
+///
+/// Older or exotic platforms that getrandom does not support can also use the custom backend
+/// mechanism to supply their own entropy source.
+///
+/// On targets without atomic pointer support (e.g. `thumbv6m-none-eabi`), the global secrets
+/// cannot be randomized and fall back to the default secrets. With the `getrandom` feature each
+/// `RandomState` still draws a fresh random per-map seed directly from the entropy source,
+/// retaining minimal HashDoS resistance; without it these platforms have none. If stronger
+/// support for these platforms is important to your application, please raise a GitHub issue.
 ///
 /// # Example
 /// ```rust
@@ -39,18 +72,24 @@ pub struct RandomState<const AVALANCHE: bool, const SPONGE: bool, const COMPACT:
 }
 
 impl<const AVALANCHE: bool, const SPONGE: bool, const COMPACT: bool, const PROTECTED: bool> RandomState<AVALANCHE, SPONGE, COMPACT, PROTECTED> {
-    /// Create a new random state with a random seed.
+    /// Create a new random state with a fresh per-instance seed and the global secrets.
     ///
-    /// The seed is always randomized by using ASLR on every new instance of RandomState.
+    /// A new seed is generated for every `RandomState` instance. With the `std` feature this uses a
+    /// fast thread-local counter mixed with stack-pointer (ASLR) entropy, where each thread's
+    /// counter is initialized from the process-wide random seed and a global thread counter;
+    /// without `std` it uses a global atomic counter initialized from the process-wide random
+    /// seed. On targets with neither, each instance draws its seed from getrandom when the
+    /// `getrandom` feature is enabled, or falls back to ASLR alone.
     ///
-    /// With the `rand` feature enabled, the secrets will be randomized using [rand::random].
-    /// Otherwise, a mix of ASLR and some other poorer sources of entropy will be mixed together to
-    /// generate the secrets. The secrets are statically cached for the lifetime of the program
-    /// after their initial generation.
+    /// The secrets are randomized once and then cached globally for the lifetime of the program.
+    /// The one-time randomization is derived from OS/platform entropy with the `getrandom`
+    /// feature, or the standard library's secure RNG with the `std` feature (the same source
+    /// `std` uses to seed its own hashers); with neither it falls back to mixing ASLR and other
+    /// weaker sources of entropy.
     ///
     /// On platforms that do not support atomic pointers, the secrets will be the default rapidhash
-    /// secrets, which are not randomized. Therefore, **targets without atomic pointer support will
-    /// not have minimal HashDoS resistance guarantees**.
+    /// secrets, which are not randomized. Therefore, **targets without atomic pointer support only
+    /// have minimal HashDoS resistance when the `getrandom` feature provides random seeds**.
     #[inline]
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
### Additions
- **`getrandom_04` feature**: opt-in seeding of the hasher seeds and secrets from OS/platform entropy via the [getrandom](https://docs.rs/getrandom) crate, without requiring `std`. This replaces the `rand` feature and enables true HashDoS resistance on targets with no ambient entropy or ASLR:
  - `wasm32-wasip1`/`wasm32-wasip2`: enabling the feature is sufficient; entropy comes from the WASI host.
  - `wasm32-unknown-unknown` (browser/node): additionally requires getrandom's `wasm_js` backend, enabled by the top-level binary. Building without the backend is a compile error rather than a silent fallback to deterministic seeding.
  - Embedded/`no_std` targets with a hardware RNG: register a getrandom [custom backend](https://docs.rs/getrandom/0.3/getrandom/#custom-backend). On targets without atomic pointer support (e.g. `thumbv6m-none-eabi`), each `RandomState` draws a fresh random seed per instance, restoring minimal HashDoS resistance where there previously was none.
- **`getrandom_03` feature**: the same as the `getrandom_04` feature, but using getrandom v0.3 to preserve the rapidhash MSRV 1.71.

### Fixes
- `RandomState` no longer produces duplicate seeds across threads whose stacks are recycled by the OS. Each thread's seed counter is now initialized from a global thread counter mixed with the process-wide random seed, instead of relying on the (frequently re-used) stack address alone.
- Better randomness handling on `no_std` targets and targets without atomics.

### Changes
- The `rand` feature is now a deprecated alias for `std` + `getrandom_03`, and the `rand` crate dependency has been removed. `RandomState` and `GlobalState` seed themselves from getrandom, the standard library's secure RNG, or ASLR-based entropy, in that order of preference depending on enabled features. The `rand` feature will be removed in a future major version.
- Documented how to achieve true seed randomization on wasm32 and embedded targets in the `RandomState` and `GlobalState` docs, and documented the one remaining gap: `GlobalState` on targets without atomic pointer support cannot be randomized, and `RandomState` with `getrandom_04` should be preferred there.

### Testing
- Added wasm32 behavioural tests, run through wasmtime in CI: without `getrandom` (`wasm32-unknown-unknown`) seeding is asserted to be fully deterministic across instances, and with `getrandom_04` (`wasm32-wasip1` + WASI entropy) seeds and secrets are asserted to differ between instances.
- Added a 1024-thread seed uniqueness test covering OS thread-stack recycling.
