### PR TITLE
Deprecate RapidRng in favour of rapidrand

### DIFF
--- a/rapidhash-bench-wasm/Cargo.toml
+++ b/rapidhash-bench-wasm/Cargo.toml
@@ -18,6 +18,8 @@ getrandom = ["rapidhash/getrandom_04"]  # used by the wasm32-wasip1 behaviour te
 rapidhash = { path = "../rapidhash", default-features = false }
 foldhash = "0.2"
 fxhash = "0.2.1"
+rand = { version = "0.10", default-features = false }
+rapidrand = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.8.1", default-features = false, features = ["rayon", "cargo_bench_support"] }

--- a/rapidhash-bench-wasm/src/lib.rs
+++ b/rapidhash-bench-wasm/src/lib.rs
@@ -10,7 +10,8 @@
 
 use std::hash::BuildHasher;
 
-use rapidhash::rng::rapidrng_fast_not_portable;
+use rand::{Rng, RngExt, SeedableRng};
+use rapidrand::RapidRng;
 
 macro_rules! bench_wasm_tuple {
     ($name:ident, $hash:path) => {
@@ -61,21 +62,17 @@ pub extern "C" fn test_wasm_global_state() -> u64 {
 /// Simulate hashing fictional (id, email) pairs, where email is len 6..60 bytes.
 fn profile_hash_tuple<B: BuildHasher + Default>() -> u64 {
     let builder = B::default();
+    let mut rng = RapidRng::seed_from_u64(0);
 
-    let mut seed = 0;
     let mut total = 0;
-
-    let mut buffer = [0u64; 8];
+    let mut buffer = [0u8; 60];
 
     for _ in 0..1_000 {
-        let ratio = f64::from(rapidrng_fast_not_portable(&mut seed) as u32) / f64::from(u32::MAX);
-        let len = usize::max(6, (ratio * 60.0) as usize);
+        rng.fill_bytes(&mut buffer);
 
-        buffer.fill_with(|| rapidrng_fast_not_portable(&mut seed));
-
-        let username: &[u8] = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, 8 * buffer.len()) };
-        let num = rapidrng_fast_not_portable(&mut seed);
-        total ^= builder.hash_one((num, &username[..len]));
+        let len = rng.random_range(6..60);
+        let num: u64 = rng.random();
+        total ^= builder.hash_one((num, &buffer[..len]));
     }
 
     total
@@ -84,19 +81,35 @@ fn profile_hash_tuple<B: BuildHasher + Default>() -> u64 {
 /// Simulate hashing a 3kb-4kb file or byte array.
 fn profile_hash_4kb<B: BuildHasher + Default>() -> u64 {
     let builder = B::default();
+    let mut rng = RapidRng::seed_from_u64(0);
 
-    let mut seed = 0;
     let mut total = 0;
-
-    let mut buffer = [0u64; 512];
+    let mut buffer = [0u8; 4096];
 
     for _ in 0..1_000 {
-        let ratio = f64::from(rapidrng_fast_not_portable(&mut seed) as u32) / f64::from(u32::MAX);
-        let len = usize::min(usize::max(3 * 512, (ratio * 4.0 * 512.0) as usize), 512);
-        buffer[0..len].fill_with(|| rapidrng_fast_not_portable(&mut seed));
-        let file_bytes: &[u8] = unsafe { std::slice::from_raw_parts(buffer.as_ptr() as *const u8, 8 * buffer.len()) };
-        total ^= builder.hash_one(&file_bytes[..len * 8]);
+        rng.fill_bytes(&mut buffer);
+
+        let len = rng.random_range(3 * 1024..4 * 1024);
+        total ^= builder.hash_one(&buffer[..len]);
     }
 
     total
+}
+
+/// Basic validity test of this code for non-WASM builds
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_profile_hash_tuple() {
+        let total = profile_hash_tuple::<rapidhash::fast::RandomState>();
+        assert_ne!(total, 0);
+    }
+
+    #[test]
+    fn test_profile_hash_4kb() {
+        let total = profile_hash_tuple::<rapidhash::fast::RandomState>();
+        assert_ne!(total, 0);
+    }
 }

--- a/rapidhash-bench/benches/bench/rng.rs
+++ b/rapidhash-bench/benches/bench/rng.rs
@@ -1,3 +1,7 @@
+//! This benchmark is now redundant since we have spun out the `rapidrand` crate.
+
+#![allow(deprecated)]
+
 use criterion::{Bencher, Criterion};
 use rand_core::{RngCore, SeedableRng};
 

--- a/rapidhash-c/Cargo.toml
+++ b/rapidhash-c/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 libc = "1.0.0-alpha.1"
 
 [dev-dependencies]
-rand = "0.9.1"
+rand = "0.10"
+rapidrand = "0.1"
 hex = "0.4.3"
 
 [build-dependencies]

--- a/rapidhash-c/src/bindings.rs
+++ b/rapidhash-c/src/bindings.rs
@@ -24,13 +24,14 @@ macro_rules! bindings {
             /// These tests are not deterministic, but should fail with a very low probability.
             #[test]
             fn flip_bit_trial() {
-                use rand::Rng;
+                use rand::{Rng, SeedableRng};
+                let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
 
                 let mut flips = std::vec![];
 
                 for len in 1..=512 {
                     let mut data = std::vec![0; len];
-                    rand::rng().fill(&mut data[..]);
+                    rng.fill_bytes(&mut data[..]);
 
                     let hash = $rust(&data, 0);
                     for byte in 0..len {

--- a/rapidhash-c/src/lib.rs
+++ b/rapidhash-c/src/lib.rs
@@ -4,7 +4,7 @@ pub use bindings::*;
 
 #[cfg(test)]
 mod tests {
-    use rand::RngCore;
+    use rand::{Rng, SeedableRng};
     use super::*;
 
     /// This test demonstrates seed-independent hash collisions in rapidhash v3 when using the
@@ -17,7 +17,7 @@ mod tests {
         fn random_slice() -> Vec<u8> {
             // generate a random 32-byte input
             let mut data = vec![0; 32];
-            let rng = &mut rand::rng();
+            let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
             rng.fill_bytes(data.as_mut_slice());
 
             // set penultimate 8 bytes to secret[1], XORed with the input length 32

--- a/rapidhash/Cargo.toml
+++ b/rapidhash/Cargo.toml
@@ -44,6 +44,7 @@ getrandom_03 = { version = "0.3", package = "getrandom", default-features = fals
 
 [dev-dependencies]
 rapidhash-c = { path = "../rapidhash-c" }
-rand = "0.9.0"
+rand = "0.10.0"
+rapidrand = "0.1.0"
 tempfile = "3.14.0" # testing rapidhash_file
 assert_cmd = "2.1.1"

--- a/rapidhash/src/inner/mod.rs
+++ b/rapidhash/src/inner/mod.rs
@@ -48,7 +48,8 @@ mod tests {
 
     use std::hash::{BuildHasher, Hash, Hasher};
     use std::collections::BTreeSet;
-    use rand::Rng;
+    use rand::{RngExt, SeedableRng};
+    use rapidrand::RapidRng;
     use crate::inner::mix_np::rapid_mix_np;
     use super::seed::{DEFAULT_RAPID_SECRETS, DEFAULT_SEED};
     use super::rapid_const::{rapidhash_rs, rapidhash_rs_seeded};
@@ -103,10 +104,11 @@ mod tests {
     #[test]
     fn all_sizes() {
         let mut hashes = BTreeSet::new();
+        let mut rng = RapidRng::from_rng(&mut rand::rng());
 
         for size in 0..=1024 {
             let mut data = std::vec![0; size];
-            rand::rng().fill(data.as_mut_slice());
+            rng.fill(data.as_mut_slice());
 
             let hash1 = rapidhash_rs(&data);
             let mut hasher = RapidHasher::default();
@@ -126,13 +128,12 @@ mod tests {
     /// These tests are not deterministic, but should fail with a very low probability.
     #[test]
     fn flip_bit_trial() {
-        use rand::Rng;
-
         let mut flips = std::vec![];
+        let mut rng = RapidRng::from_rng(&mut rand::rng());
 
         for len in 1..=512 {
             let mut data = std::vec![0; len];
-            rand::rng().fill(&mut data[..]);
+            rng.fill(&mut data[..]);
 
             let hash = rapidhash_rs(&data);
             for byte in 0..len {
@@ -206,13 +207,12 @@ mod tests {
     /// These tests are not deterministic, but should fail with a very low probability.
     #[test]
     fn flip_bit_trial_streaming() {
-        use rand::Rng;
-
         let mut flips = std::vec![];
+        let mut rng = RapidRng::from_rng(&mut rand::rng());
 
         for len in 1..=300 {
             let mut data = std::vec![0; len];
-            rand::rng().fill(&mut data[..]);
+            rng.fill(&mut data[..]);
 
             let hash = streaming_hash(&data);
             for byte in 0..len {
@@ -254,12 +254,13 @@ mod tests {
     #[cfg(target_endian = "little")]
     #[test]
     fn compare_to_c() {
-        use rand::Rng;
+        use rand::RngExt;
         use rapidhash_c::rapidhashcc_rs;
+        let mut rng = RapidRng::from_rng(&mut rand::rng());
 
         for len in 0..=512 {
             let mut data = std::vec![0; len];
-            rand::rng().fill(&mut data[..]);
+            rng.fill(&mut data[..]);
 
             for byte in 0..len {
                 for bit in 0..8 {

--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -395,7 +395,6 @@ pub(crate) mod secrets {
     mod tests {
         extern crate std;
 
-        use std::arch::is_s390x_feature_detected;
         use std::collections::BTreeSet;
         use super::*;
 

--- a/rapidhash/src/rng.rs
+++ b/rapidhash/src/rng.rs
@@ -1,5 +1,7 @@
 //! Fast random number generation using rapidhash mixing.
 
+#![allow(deprecated)]
+
 #[cfg(feature = "rng")]
 use rand_core::{RngCore, SeedableRng, impls};
 use crate::util::mix::rapid_mix;
@@ -24,6 +26,7 @@ const RAPID_SECRET: [u64; 3] = [0x2d358dccaa6c78a5, 0x8bb84b93962eacc9, 0x4b33a6
 /// is simple a position in a constant sequence. Future work could involve using a wider state to
 /// ensure we can generate many different sequences.
 #[inline]
+#[deprecated(since = "4.5.0", note = "use the `rapidrand` crate instead")]
 pub fn rapidrng_fast(seed: &mut u64) -> u64 {
     *seed = seed.wrapping_add(RAPID_SECRET[0]);
     rapid_mix::<false>(*seed, *seed ^ RAPID_SECRET[1])
@@ -37,6 +40,7 @@ pub fn rapidrng_fast(seed: &mut u64) -> u64 {
 ///
 /// Used in the rapidhash WASM benchmarks.
 #[inline]
+#[deprecated(since = "4.5.0", note = "use the `rapidrand` crate instead")]
 pub fn rapidrng_fast_not_portable(seed: &mut u64) -> u64 {
     *seed = seed.wrapping_add(RAPID_SECRET[0]);
     rapid_mix_np_low_quality(*seed, RAPID_SECRET[1])
@@ -122,6 +126,7 @@ fn rapid_mix_np_low_quality(x: u64, y: u64) -> u64 {
     docsrs
 ))]
 #[inline]
+#[deprecated(since = "4.5.0", note = "use the `rapidrand` crate instead")]
 pub fn rapidrng_time(seed: &mut u64) -> u64 {
     let time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap();
     // NOTE limited entropy: only a few of the time.as_secs bits will change between calls, and the
@@ -148,6 +153,7 @@ pub fn rapidrng_time(seed: &mut u64) -> u64 {
 /// println!("{}", rng.next());
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[deprecated(since = "4.5.0", note = "use the `rapidrand` crate instead")]
 pub struct RapidRng {
     seed: u64,
 }

--- a/rapidhash/src/util/macros.rs
+++ b/rapidhash/src/util/macros.rs
@@ -3,8 +3,10 @@ macro_rules! compare_to_c {
     ($test:ident, $rust_fn:path, $compact_fn:path, $cc_fn:ident) => {
         #[test]
         fn $test() {
-            use rand::Rng;
             use rapidhash_c::$cc_fn;
+
+            use rand::{Rng, SeedableRng};
+            let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
 
             // test zero-length input
             let rust_hash = $rust_fn(&[], &DEFAULT_RAPID_SECRETS);
@@ -16,7 +18,7 @@ macro_rules! compare_to_c {
             // test up to 512 bytes
             for len in 0..=512 {
                 let mut data = std::vec![0; len];
-                rand::rng().fill(&mut data[..]);
+                rng.fill_bytes(&mut data[..]);
 
                 for byte in 0..len {
                     for bit in 0..8 {
@@ -40,13 +42,14 @@ macro_rules! flip_bit_trial {
     ($test:ident, $hash:path) => {
         #[test]
         fn $test() {
-            use rand::Rng;
+            use rand::{Rng, SeedableRng};
+            let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
 
             let mut flips = std::vec![];
 
             for len in 1..=256 {
                 let mut data = std::vec![0; len];
-                rand::rng().fill(&mut data[..]);
+                rng.fill_bytes(&mut data[..]);
 
                 let hash = $hash(&data, &DEFAULT_RAPID_SECRETS);
                 for byte in 0..len {
@@ -100,12 +103,13 @@ macro_rules! compare_rapidhash_file {
     ($test:ident, $hash:path, $file:path) => {
         #[test]
         fn $test() {
-            use rand::RngCore;
+            use rand::{Rng, SeedableRng};
+            let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
 
             const LENGTH: usize = 1024;
             for len in 1..=LENGTH {
                 let mut data = vec![0u8; len];
-                rand::rng().fill_bytes(&mut data);
+                rng.fill_bytes(&mut data);
 
                 let mut file = tempfile::tempfile().unwrap();
                 file.write_all(&data).unwrap();
@@ -126,14 +130,16 @@ macro_rules! compare_rapid_stream_hasher {
         #[test]
         fn $test() {
             extern crate alloc;
-            use rand::RngCore;
+
+            use rand::{Rng, SeedableRng};
+            let mut rng = rapidrand::RapidRng::from_rng(&mut rand::rng());
 
             type H<'a> = $hasher;
 
             // test every length and every chunking size for the stream hasher
             for len in 0..1024 {
                 let mut data = alloc::vec![0u8; len];
-                rand::rng().fill_bytes(&mut data);
+                rng.fill_bytes(&mut data);
 
                 let expected_hash = $hash(&data, &DEFAULT_RAPID_SECRETS);
 

--- a/rapidhash/src/v3/mod.rs
+++ b/rapidhash/src/v3/mod.rs
@@ -23,7 +23,7 @@ pub use seed::*;
 mod tests {
     extern crate std;
 
-    use rand::Rng;
+    use rand::RngExt;
     use crate::util::macros::{compare_to_c, flip_bit_trial};
     use super::*;
 


### PR DESCRIPTION
RapidRng has been spun out into the [`rapidrand`](https://github.com/hoxxep/rapidrand) crate to make versioning easier and more tied to rand than hash outputs. It also includes much more thorough testing and benchmarking.