### PR TITLE
Fix size tests for s390x architectures with 8-byte alignment for u128

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -105,6 +105,45 @@ jobs:
         working-directory: rapidhash-msrv
         run: cargo test --no-fail-fast --all-features
 
+  size-checks:
+    # Cross-check the compile-time struct-size assertions in rapidhash-msrv over a range of targets.
+    # `cargo check` const-evaluates the assertions without linking, running, or even libtest, so no
+    # cross toolchain or emulator is needed — only the target's prebuilt std (where applicable).
+    # Struct size is endianness-independent, so the axes worth covering are pointer width and u128
+    # alignment, plus the wasm (COMPACT) and no-atomics (GlobalSecrets) instantiations:
+    #   - x86_64/aarch64: 64-bit, u128 aligned to 16
+    #   - s390x:          64-bit, u128 aligned to 8 (the case that broke the old exact-size test)
+    #   - i686:           32-bit
+    #   - wasm32:         32-bit, exercises the COMPACT=true type aliases
+    #   - thumbv6m:       32-bit, no_std + no atomics (checks the non-atomic GlobalSecrets is a ZST)
+    # The dependency graph here is tiny (just rapidhash + rustversion), so no build cache is used.
+    name: "Size checks (${{ matrix.target }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            args: --features std
+          - target: aarch64-unknown-linux-gnu
+            args: --features std
+          - target: s390x-unknown-linux-gnu
+            args: --features std
+          - target: i686-unknown-linux-gnu
+            args: --features std
+          - target: wasm32-unknown-unknown
+            args: --features std
+          - target: thumbv6m-none-eabi
+            args: --no-default-features
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Cross-check compile-time struct size assertions
+        working-directory: rapidhash-msrv
+        run: cargo check ${{ matrix.args }} --target ${{ matrix.target }}
+
   test-c:
     name: "Test (C implementations)"
     runs-on: ubuntu-latest

--- a/rapidhash-bench/src/lib.rs
+++ b/rapidhash-bench/src/lib.rs
@@ -9,16 +9,16 @@ mod tests {
         #[test]
         fn test_hashmap_size() {
             // only enable when std is available
-            assert_eq!(core::mem::size_of::<rapidhash::RapidHashMap<u32, u32>>(), 40);
-            assert_eq!(core::mem::size_of::<foldhash::HashMap<u32, u32>>(), 40);
+            assert!(core::mem::size_of::<rapidhash::RapidHashMap<u32, u32>>() <= 40);
+            assert!(core::mem::size_of::<foldhash::HashMap<u32, u32>>() <= 40);
         }
 
         #[cfg(feature = "bench")]
         #[test]
         fn test_hasher_size() {
             // only enable when std is available
-            assert_eq!(core::mem::size_of::<rapidhash::fast::RapidHasher>(), 48);
-            assert_eq!(core::mem::size_of::<foldhash::fast::FoldHasher>(), 48);
+            assert!(core::mem::size_of::<rapidhash::fast::RapidHasher>() <= 48);
+            assert!(core::mem::size_of::<foldhash::fast::FoldHasher>() <= 48);
         }
     }
 

--- a/rapidhash-msrv/src/lib.rs
+++ b/rapidhash-msrv/src/lib.rs
@@ -1,5 +1,57 @@
+//! This crate doubles as the home for rapidhash's struct-size checks.
+//!
+//! They live here, rather than in the `rapidhash` crate's own tests, for two reasons:
+//! - This crate has minimal dependencies, so `cargo check --target <T>` cross-checks them cheaply
+//!   (no target linker, emulator, or even libtest required) across a matrix of targets in CI. That
+//!   is how we catch layout regressions on targets we can't natively run — e.g. s390x, where
+//!   `u128` is 8-byte aligned rather than 16-byte, so the same struct is smaller than on
+//!   x86-64/aarch64.
+//! - As compile-time (`const`) assertions they would abort compilation if they ever tripped, so
+//!   keeping them out of the published `rapidhash` crate ensures a bad bound can never break a
+//!   downstream build — only this unpublished, path-only crate's compilation.
+//!
+//! The checks are deliberately *not* `#[cfg(test)]`: they fire on a plain `cargo check`, so they
+//! also cover no-libtest targets like `thumbv6m-none-eabi` (no atomics, no std). Struct size is
+//! endianness-independent, so the axes that matter are pointer width and `u128` alignment, plus the
+//! target-specific `GlobalSecrets`/`COMPACT` instantiations — not byte order.
+
+#![no_std]
+
+/// Compile-time struct-size checks, evaluated on every compile of this crate.
+///
+/// Sizes are asserted as upper bounds because the `u128` sponge field's alignment — and therefore
+/// the surrounding struct padding — is target-dependent: 16 bytes on x86-64/aarch64, 8 bytes on
+/// s390x. `RandomState`/`GlobalState` use exact checks instead, to guard the invariant that their
+/// `GlobalSecrets` field stays zero-sized (which is what keeps `HashMap<K, V, RandomState>` small).
+mod size_checks {
+    use core::mem::size_of;
+
+    // Embeds the u128 sponge, so the size tracks u128 alignment.
+    #[cfg(target_pointer_width = "64")]
+    const _: () = assert!(size_of::<rapidhash::quality::RapidHasher<'static>>() <= 48);
+    #[cfg(target_pointer_width = "32")]
+    const _: () = assert!(size_of::<rapidhash::quality::RapidHasher<'static>>() <= 32);
+
+    // Just a u64 seed and a reference; the same bound holds on 32- and 64-bit targets.
+    const _: () = assert!(size_of::<rapidhash::fast::SeedableState<'static>>() <= 16);
+
+    // A u64 seed plus a zero-sized GlobalSecrets, and the ZST alone, respectively.
+    const _: () = assert!(size_of::<rapidhash::fast::RandomState>() == 8);
+    const _: () = assert!(size_of::<rapidhash::fast::GlobalState>() == 0);
+
+    #[cfg(feature = "std")]
+    #[cfg(target_pointer_width = "64")]
+    const _: () = assert!(size_of::<rapidhash::RapidHashMap<u64, u64>>() <= 40);
+    #[cfg(feature = "std")]
+    #[cfg(target_pointer_width = "32")]
+    const _: () = assert!(size_of::<rapidhash::RapidHashMap<u64, u64>>() <= 24);
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
+    extern crate std;
+
     #[test]
     fn test_rapidhash() {
         assert_eq!(rapidhash::v3::rapidhash_v3(b"hello"), 3327445792987248966);

--- a/rapidhash/src/collections.rs
+++ b/rapidhash/src/collections.rs
@@ -103,8 +103,8 @@ mod tests {
     #[test]
     fn test_hashmap_size() {
         #[cfg(target_pointer_width = "64")]
-        assert_eq!(core::mem::size_of::<RapidHashMap<u64, u64>>(), 40);
+        assert!(core::mem::size_of::<RapidHashMap<u64, u64>>() <= 40);
         #[cfg(target_pointer_width = "32")]
-        assert_eq!(core::mem::size_of::<RapidHashMap<u64, u64>>(), 24);
+        assert!(core::mem::size_of::<RapidHashMap<u64, u64>>() <= 24);
     }
 }

--- a/rapidhash/src/collections.rs
+++ b/rapidhash/src/collections.rs
@@ -100,11 +100,4 @@ mod tests {
         assert!(!set.contains("na"));
     }
 
-    #[test]
-    fn test_hashmap_size() {
-        #[cfg(target_pointer_width = "64")]
-        assert!(core::mem::size_of::<RapidHashMap<u64, u64>>() <= 40);
-        #[cfg(target_pointer_width = "32")]
-        assert!(core::mem::size_of::<RapidHashMap<u64, u64>>() <= 24);
-    }
 }

--- a/rapidhash/src/inner/rapid_hasher.rs
+++ b/rapidhash/src/inner/rapid_hasher.rs
@@ -215,9 +215,9 @@ mod tests {
     #[test]
     fn test_hasher_size() {
         #[cfg(target_pointer_width = "64")]
-        assert_eq!(core::mem::size_of::<RapidHasher::<true, true, false, false>>(), 48);
+        assert!(core::mem::size_of::<RapidHasher::<true, true, false, false>>() <= 48);
         #[cfg(target_pointer_width = "32")]
-        assert_eq!(core::mem::size_of::<RapidHasher::<true, true, false, false>>(), 32);
+        assert!(core::mem::size_of::<RapidHasher::<true, true, false, false>>() <= 32);
     }
 
     /// Test that writing a single u64 outputs the same as writing the equivalent bytes.

--- a/rapidhash/src/inner/rapid_hasher.rs
+++ b/rapidhash/src/inner/rapid_hasher.rs
@@ -212,14 +212,6 @@ mod tests {
     use crate::fast::SeedableState;
     use super::*;
 
-    #[test]
-    fn test_hasher_size() {
-        #[cfg(target_pointer_width = "64")]
-        assert!(core::mem::size_of::<RapidHasher::<true, true, false, false>>() <= 48);
-        #[cfg(target_pointer_width = "32")]
-        assert!(core::mem::size_of::<RapidHasher::<true, true, false, false>>() <= 32);
-    }
-
     /// Test that writing a single u64 outputs the same as writing the equivalent bytes.
     ///
     /// Does not apply if the algorithm is using a sponge.

--- a/rapidhash/src/inner/state/global_state.rs
+++ b/rapidhash/src/inner/state/global_state.rs
@@ -101,11 +101,6 @@ mod tests {
     type GlobalState = super::GlobalState<false, true, false, false>;
 
     #[test]
-    fn test_global_state_size() {
-        assert_eq!(core::mem::size_of::<GlobalState>(), 0);
-    }
-
-    #[test]
     fn test_global_state() {
         let state1 = GlobalState::new();
         let state2 = GlobalState::new();

--- a/rapidhash/src/inner/state/random_state.rs
+++ b/rapidhash/src/inner/state/random_state.rs
@@ -129,11 +129,6 @@ mod tests {
     type RandomState = super::RandomState<false, true, false, false>;
 
     #[test]
-    fn test_random_state_size() {
-        assert_eq!(core::mem::size_of::<RandomState>(), 8);
-    }
-
-    #[test]
     fn test_random_state() {
         let state1 = RandomState::new();
         let state2 = RandomState::new();

--- a/rapidhash/src/inner/state/seedable_state.rs
+++ b/rapidhash/src/inner/state/seedable_state.rs
@@ -164,11 +164,6 @@ mod tests {
     type SeedableState<'s> = super::SeedableState<'s, false, true, false, false>;
 
     #[test]
-    fn test_seedable_state_size() {
-        assert!(core::mem::size_of::<SeedableState>() <= 16);
-    }
-
-    #[test]
     fn test_random_init() {
         let state1 = SeedableState::random();
         let state2 = SeedableState::random();

--- a/rapidhash/src/inner/state/seedable_state.rs
+++ b/rapidhash/src/inner/state/seedable_state.rs
@@ -165,9 +165,6 @@ mod tests {
 
     #[test]
     fn test_seedable_state_size() {
-        #[cfg(target_pointer_width = "64")]
-        assert_eq!(core::mem::size_of::<SeedableState>(), 16);
-        #[cfg(target_pointer_width = "32")]
         assert!(core::mem::size_of::<SeedableState>() <= 16);
     }
 


### PR DESCRIPTION
Per issue #90 that demonstrated tests were failing on s390x targets.