### PR TITLE
Fix new thread seeding for std but no-atomic targets

### DIFF
--- a/rapidhash/src/inner/seeding.rs
+++ b/rapidhash/src/inner/seeding.rs
@@ -43,9 +43,14 @@ pub(crate) mod seed {
 
             seed = RANDOM_SEED.with(|cell| {
                 let mut seed = cell.get();
-                #[cfg(all(feature = "std", target_has_atomic = "ptr"))] {
+                #[cfg(target_has_atomic = "ptr")] {
                     if seed == 0 {
                         seed = init_thread_seed(arbitrary);
+                    }
+                }
+                #[cfg(not(target_has_atomic = "ptr"))] {
+                    if seed == 0 {
+                        seed = super::secrets::generate_random();
                     }
                 }
                 seed = seed.wrapping_add(DEFAULT_SECRETS[0]);


### PR DESCRIPTION
On targets with std but no atomics, we now mix in `generate_random()` into the seed during the thread-local initialisation. Otherwise we'd run into the same cached threads having the same seed bug we've recently fixed.